### PR TITLE
Correct stop command

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -62,6 +62,6 @@ RUN mkdir -p /root/.ansible/tmp /tmp/ansible \
     && chmod -R 1777 /tmp/ansible
 
 EXPOSE 22
-STOPSIGNAL SIGRTMIN+3
+STOPSIGNAL SIGTERM
 VOLUME ["/sys/fs/cgroup", "/run", "/tmp"]
 CMD ["/sbin/init"]


### PR DESCRIPTION
We hope this will fix the failure in CI on https://github.com/pulibrary/princeton_ansible/pull/6672.

Per https://docs.docker.com/reference/cli/docker/container/stop/. We think this was a typo or copy/pasta.