### PR TITLE
fix: keep apt working when pulmirror is unreachable

### DIFF
--- a/ansible/roles/base/tasks/apt_upgrade.yml
+++ b/ansible/roles/base/tasks/apt_upgrade.yml
@@ -1,0 +1,29 @@
+---
+- name: Getting guest operating system information.
+  ansible.builtin.debug:
+    msg: "OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+
+- name: Updating the operating system.
+  ansible.builtin.apt:
+    name: "*"
+    state: latest # noqa package-latest
+    update_cache: true
+    lock_timeout: 1800
+  register: _apt_upgrade
+  retries: 5
+  delay: 15
+
+- name: Installing additional packages.
+  ansible.builtin.apt:
+    name: "{{ base_additional_packages[ansible_os_family] }}"
+    state: latest # noqa package-latest
+    lock_timeout: 900
+  register: _apt_pkgs
+  retries: 5
+  delay: 15
+
+- name: Installing cloud-init.
+  ansible.builtin.apt:
+    name: cloud-init
+    state: latest # noqa package-latest
+  when: enable_cloudinit == 'true' and ansible_distribution_version | int >= 12

--- a/ansible/roles/base/tasks/debian.yml
+++ b/ansible/roles/base/tasks/debian.yml
@@ -21,6 +21,24 @@
   failed_when: false
   when: ansible_os_family == "Debian"
 
+# Maintainer scripts restart their own services through deb-systemd-invoke,
+# which asks /usr/sbin/policy-rc.d for permission first and treats exit code 101
+# as "do not run". Those restarts are pointless in an image that is about to be
+# shut down, and they are a real source of failed builds: the openssh-server
+# upgrade restarts ssh.service and ssh.socket together, and when systemd refuses
+# that job the postinst dies, leaving the package half-configured so every later
+# apt run fails with "1 not fully installed or removed". The clean role deletes
+# the file again so a deployed instance handles its services normally.
+- name: Prevent package scripts from restarting services during the build
+  ansible.builtin.copy:
+    dest: /usr/sbin/policy-rc.d
+    mode: "0755"
+    content: |
+      #!/bin/sh
+      # Added by the vm-builds base role, removed again by the clean role.
+      exit 101
+  when: ansible_os_family == "Debian"
+
 - name: Wait for any running apt/dpkg processes to complete
   ansible.builtin.shell: |
     timeout=300
@@ -39,6 +57,9 @@
   changed_when: false
   when: ansible_os_family == "Debian"
 
+# The base cloud image may arrive with a package left unconfigured by its own
+# boot-time unattended upgrade. apt refuses to do anything else until that is
+# settled, so finish it now that service restarts are suppressed.
 - name: Ensure dpkg is configured (best-effort)
   ansible.builtin.command: dpkg --configure -a
   changed_when: false
@@ -47,31 +68,23 @@
 
 - name: Updating the operating system and installing additional packages.
   block:
-    - name: Getting guest operating system information.
+    - name: Update and install packages
+      ansible.builtin.include_tasks: apt_upgrade.yml
+  rescue:
+    # A failure here nearly always means a maintainer script died mid-configure.
+    # Repairing dpkg and running the same steps once more turns a dead build into
+    # a working image instead of forcing a 30 minute rebuild.
+    - name: Report the apt failure that is being repaired
       ansible.builtin.debug:
-        msg: "OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+        msg: >-
+          apt failed ({{ ansible_failed_result.msg | default('unknown error') }});
+          repairing dpkg and retrying once.
 
-    - name: Updating the operating system.
-      ansible.builtin.apt:
-        name: "*"
-        state: latest # noqa package-latest
-        update_cache: true
-        lock_timeout: 1800
-      register: _apt_upgrade
-      retries: 5
-      delay: 15
+    - name: Repair an interrupted dpkg run
+      ansible.builtin.command: dpkg --configure -a
+      register: _dpkg_repair
+      changed_when: _dpkg_repair.rc == 0
+      failed_when: false
 
-    - name: Installing additional packages.
-      ansible.builtin.apt:
-        name: "{{ base_additional_packages[ansible_os_family] }}"
-        state: latest # noqa package-latest
-        lock_timeout: 900
-      register: _apt_pkgs
-      retries: 5
-      delay: 15
-
-    - name: Installing cloud-init.
-      ansible.builtin.apt:
-        name: cloud-init
-        state: latest # noqa package-latest
-      when: enable_cloudinit == 'true' and ansible_distribution_version | int >= 12
+    - name: Update and install packages (retry after repairing dpkg)
+      ansible.builtin.include_tasks: apt_upgrade.yml

--- a/ansible/roles/clean/tasks/debian.yml
+++ b/ansible/roles/clean/tasks/debian.yml
@@ -106,3 +106,12 @@
 
 - name: SSH hardening (AllowUsers pulsys only on final image)
   ansible.builtin.include_tasks: ssh_harden.yml
+
+# The base role blocks service restarts from package scripts while the image is
+# being built. Leaving that in place would silently stop every service from
+# being started or restarted by apt on the deployed instance, including the
+# first-boot security tool installers, so it has to go before the image ships.
+- name: Allow package scripts to manage services again on the finished image
+  ansible.builtin.file:
+    path: /usr/sbin/policy-rc.d
+    state: absent

--- a/ansible/roles/mirrors/defaults/main.yml
+++ b/ansible/roles/mirrors/defaults/main.yml
@@ -1,3 +1,13 @@
 ---
 pul_mirror_host: pulmirror.princeton.edu
 
+# Upstream archives used when the PUL mirror cannot be reached.
+pul_upstream_archive_host: archive.ubuntu.com
+pul_upstream_security_host: security.ubuntu.com
+
+# Reachability probe for the PUL mirror (seconds).
+pul_mirror_probe_timeout: 10
+pul_mirror_validate_certs: true
+
+# Set to true to abort instead of falling back to the upstream archive.
+pul_mirror_required: false

--- a/ansible/roles/mirrors/tasks/debian.yml
+++ b/ansible/roles/mirrors/tasks/debian.yml
@@ -8,19 +8,38 @@
   ansible.builtin.set_fact:
     ubuntu_codename: "{{ ansible_distribution_release | default(ansible_lsb.codename) }}"
 
-# Ubuntu 24.04+ ships stock sources in deb822 format at
-# /etc/apt/sources.list.d/ubuntu.sources. Where that file exists it already is a
-# complete upstream fallback, so we leave it in place and skip our own .list
-# drop-ins for archive/security; duplicating it only produces
-# "configured multiple times" warnings.
-- name: Look for deb822 stock sources
+# We deliberately never rewrite /etc/apt/sources.list. Whatever Ubuntu shipped
+# there (one-line entries on 22.04, deb822 ubuntu.sources on 24.04+) already is
+# the upstream fallback this role wants to guarantee, and editing it by regexp is
+# the easiest way to leave a host with no usable apt source at all. Instead,
+# detect what the distribution configures and only fill in the gaps.
+- name: Look for stock deb822 sources (Ubuntu 24.04+)
   ansible.builtin.stat:
     path: /etc/apt/sources.list.d/ubuntu.sources
-  register: pul_mirror_stock_deb822
+  register: pul_stock_deb822
 
-- name: Record whether stock upstream sources are already configured
+- name: Look for active upstream archive entries in /etc/apt/sources.list
+  ansible.builtin.find:
+    paths: /etc/apt
+    patterns: sources.list
+    contains: '^deb\s+(\[[^]]*\]\s+)?https?://\S+\s+{{ ubuntu_codename }}\s'
+  register: pul_stock_archive
+
+- name: Look for active upstream security entries in /etc/apt/sources.list
+  ansible.builtin.find:
+    paths: /etc/apt
+    patterns: sources.list
+    contains: '^deb\s+(\[[^]]*\]\s+)?https?://\S+\s+{{ ubuntu_codename }}-security\s'
+  register: pul_stock_security
+
+- name: Record which upstream pockets the distribution already configures
   ansible.builtin.set_fact:
-    pul_upstream_stock_present: "{{ pul_mirror_stock_deb822.stat.exists }}"
+    pul_upstream_archive_present: >-
+      {{ pul_stock_deb822.stat.exists
+         or (pul_stock_archive.matched | default(0) | int) > 0 }}
+    pul_upstream_security_present: >-
+      {{ pul_stock_deb822.stat.exists
+         or (pul_stock_security.matched | default(0) | int) > 0 }}
 
 # The PUL mirror is a convenience, never a hard dependency: probe it first so an
 # outage degrades to the upstream archive instead of failing the build (or, on a
@@ -38,12 +57,18 @@
 - name: Record PUL mirror availability
   ansible.builtin.set_fact:
     pul_mirror_available: "{{ (pul_mirror_probe.status | default(0)) == 200 }}"
+    # A connection-level failure reports status -1, which on its own tells you
+    # nothing; carry the underlying error so an expired certificate or DNS
+    # problem is obvious in the build log instead of looking like an outage.
+    pul_mirror_probe_reason: >-
+      HTTP {{ pul_mirror_probe.status | default('n/a') }}
+      {{ '- ' ~ pul_mirror_probe.msg if pul_mirror_probe.msg is defined else '' }}
 
 - name: Fail when the PUL mirror is required but unreachable
   ansible.builtin.fail:
     msg: >-
       {{ pul_mirror_host }} is unreachable
-      (HTTP {{ pul_mirror_probe.status | default('n/a') }})
+      ({{ pul_mirror_probe_reason | trim }})
       and pul_mirror_required is true.
   when:
     - pul_mirror_required | bool
@@ -53,47 +78,48 @@
   ansible.builtin.debug:
     msg: >-
       {{ pul_mirror_host }} is unreachable
-      (HTTP {{ pul_mirror_probe.status | default('n/a') }});
+      ({{ pul_mirror_probe_reason | trim }});
       using {{ pul_upstream_archive_host }} instead.
   when: not pul_mirror_available
 
-# Comment out ALL stock pocket lines in the default sources.list.
-# We re-add archive/updates/backports (pulmirror when available, upstream
-# always) and -security pointing at Canonical, via dedicated files in
-# sources.list.d/. Doing this unconditionally avoids the "configured multiple
-# times" warnings that appear when the stock lines coexist with our drop-ins.
-- name: Comment stock Ubuntu pocket lines in /etc/apt/sources.list
-  ansible.builtin.replace:
-    path: /etc/apt/sources.list
-    regexp: '^(deb\s+(?:http|https)://(?:archive|security)\.ubuntu\.com/ubuntu\s+{{ ubuntu_codename }}(?:-\w+)?\s+.*)$'
-    replace: '# \1'
-  when: not pul_upstream_stock_present
-  notify: apt update
-
-# Upstream archive is always configured, whether or not pulmirror answered, so
-# apt keeps working if the mirror disappears later in the host's life.
-- name: Ensure the upstream Ubuntu archive remains configured as a fallback
+# Only add upstream drop-ins where the distribution has none. Adding them
+# alongside the stock entries points apt at the same suite twice, which makes
+# every later apt run emit a page of "configured multiple times" warnings.
+- name: Ensure the upstream Ubuntu archive is configured as a fallback
   ansible.builtin.apt_repository:
     repo: "deb http://{{ pul_upstream_archive_host }}/ubuntu {{ item }} main restricted universe multiverse"
     state: present
-    filename: "20-ubuntu-archive"
+    filename: "{{ pul_upstream_archive_filename }}"
     update_cache: no
   loop:
     - "{{ ubuntu_codename }}"
     - "{{ ubuntu_codename }}-updates"
     - "{{ ubuntu_codename }}-backports"
-  when: not pul_upstream_stock_present
+  when: not (pul_upstream_archive_present | bool)
+
+- name: Remove our archive drop-in when the distribution already provides one
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/{{ pul_upstream_archive_filename }}.list"
+    state: absent
+  when: pul_upstream_archive_present | bool
 
 # Security stays on Canonical
 - name: Ensure default security repo is present
   ansible.builtin.apt_repository:
     repo: "deb http://{{ pul_upstream_security_host }}/ubuntu {{ ubuntu_codename }}-security main restricted universe multiverse"
     state: present
-    filename: "10-security"
+    filename: "{{ pul_upstream_security_filename }}"
     update_cache: no
-  when: not pul_upstream_stock_present
+  when: not (pul_upstream_security_present | bool)
 
-# pulmirror for archive/updates/backports
+- name: Remove our security drop-in when the distribution already provides one
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/{{ pul_upstream_security_filename }}.list"
+    state: absent
+  when: pul_upstream_security_present | bool
+
+# pulmirror for archive/updates/backports. Its URI differs from the upstream
+# archive, so this adds a genuinely new source rather than a duplicate one.
 - name: Add PUL mirror (archive/updates/backports)
   ansible.builtin.apt_repository:
     repo: "deb https://{{ pul_mirror_host }}/mirror/ubuntu {{ item }} main restricted universe multiverse"

--- a/ansible/roles/mirrors/tasks/debian.yml
+++ b/ansible/roles/mirrors/tasks/debian.yml
@@ -8,17 +8,90 @@
   ansible.builtin.set_fact:
     ubuntu_codename: "{{ ansible_distribution_release | default(ansible_lsb.codename) }}"
 
+# Ubuntu 24.04+ ships stock sources in deb822 format at
+# /etc/apt/sources.list.d/ubuntu.sources. Where that file exists it already is a
+# complete upstream fallback, so we leave it in place and skip our own .list
+# drop-ins for archive/security; duplicating it only produces
+# "configured multiple times" warnings.
+- name: Look for deb822 stock sources
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list.d/ubuntu.sources
+  register: pul_mirror_stock_deb822
+
+- name: Record whether stock upstream sources are already configured
+  ansible.builtin.set_fact:
+    pul_upstream_stock_present: "{{ pul_mirror_stock_deb822.stat.exists }}"
+
+# The PUL mirror is a convenience, never a hard dependency: probe it first so an
+# outage degrades to the upstream archive instead of failing the build (or, on a
+# running host, leaving apt with no usable source at all).
+- name: Check whether the PUL mirror is reachable
+  ansible.builtin.uri:
+    url: "https://{{ pul_mirror_host }}/mirror/ubuntu/dists/{{ ubuntu_codename }}/Release"
+    method: HEAD
+    timeout: "{{ pul_mirror_probe_timeout }}"
+    validate_certs: "{{ pul_mirror_validate_certs }}"
+  register: pul_mirror_probe
+  changed_when: false
+  failed_when: false
+
+- name: Record PUL mirror availability
+  ansible.builtin.set_fact:
+    pul_mirror_available: "{{ (pul_mirror_probe.status | default(0)) == 200 }}"
+
+- name: Fail when the PUL mirror is required but unreachable
+  ansible.builtin.fail:
+    msg: >-
+      {{ pul_mirror_host }} is unreachable
+      (HTTP {{ pul_mirror_probe.status | default('n/a') }})
+      and pul_mirror_required is true.
+  when:
+    - pul_mirror_required | bool
+    - not pul_mirror_available
+
+- name: Report the fallback to the upstream Ubuntu archive
+  ansible.builtin.debug:
+    msg: >-
+      {{ pul_mirror_host }} is unreachable
+      (HTTP {{ pul_mirror_probe.status | default('n/a') }});
+      using {{ pul_upstream_archive_host }} instead.
+  when: not pul_mirror_available
+
 # Comment out ALL stock pocket lines in the default sources.list.
-# We re-add archive/updates/backports pointing at pulmirror, and
-# -security pointing at Canonical, via dedicated files in sources.list.d/.
-# Doing this unconditionally avoids the "configured multiple times"
-# warnings that appear when the stock lines coexist with our drop-ins.
+# We re-add archive/updates/backports (pulmirror when available, upstream
+# always) and -security pointing at Canonical, via dedicated files in
+# sources.list.d/. Doing this unconditionally avoids the "configured multiple
+# times" warnings that appear when the stock lines coexist with our drop-ins.
 - name: Comment stock Ubuntu pocket lines in /etc/apt/sources.list
   ansible.builtin.replace:
     path: /etc/apt/sources.list
     regexp: '^(deb\s+(?:http|https)://(?:archive|security)\.ubuntu\.com/ubuntu\s+{{ ubuntu_codename }}(?:-\w+)?\s+.*)$'
     replace: '# \1'
+  when: not pul_upstream_stock_present
   notify: apt update
+
+# Upstream archive is always configured, whether or not pulmirror answered, so
+# apt keeps working if the mirror disappears later in the host's life.
+- name: Ensure the upstream Ubuntu archive remains configured as a fallback
+  ansible.builtin.apt_repository:
+    repo: "deb http://{{ pul_upstream_archive_host }}/ubuntu {{ item }} main restricted universe multiverse"
+    state: present
+    filename: "20-ubuntu-archive"
+    update_cache: no
+  loop:
+    - "{{ ubuntu_codename }}"
+    - "{{ ubuntu_codename }}-updates"
+    - "{{ ubuntu_codename }}-backports"
+  when: not pul_upstream_stock_present
+
+# Security stays on Canonical
+- name: Ensure default security repo is present
+  ansible.builtin.apt_repository:
+    repo: "deb http://{{ pul_upstream_security_host }}/ubuntu {{ ubuntu_codename }}-security main restricted universe multiverse"
+    state: present
+    filename: "10-security"
+    update_cache: no
+  when: not pul_upstream_stock_present
 
 # pulmirror for archive/updates/backports
 - name: Add PUL mirror (archive/updates/backports)
@@ -31,14 +104,7 @@
     - "{{ ubuntu_codename }}"
     - "{{ ubuntu_codename }}-updates"
     - "{{ ubuntu_codename }}-backports"
-
-# Security stays on Canonical
-- name: Ensure default security repo is present
-  ansible.builtin.apt_repository:
-    repo: "deb http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security main restricted universe multiverse"
-    state: present
-    filename: "10-security"
-    update_cache: no
+  when: pul_mirror_available
 
 # Soft-prefer the PUL mirror without breaking fallbacks
 - name: Pin PUL mirror slightly higher than defaults
@@ -49,12 +115,42 @@
       Package: *
       Pin: origin "{{ pul_mirror_host }}"
       Pin-Priority: 600
+  when: pul_mirror_available
 
-- name: apt update (with retries)
-  ansible.builtin.apt:
-    update_cache: yes
-    cache_valid_time: 3600
-  register: aptu
-  retries: 5
-  delay: 3
-  until: aptu is succeeded
+- name: Remove PUL mirror configuration while it is unreachable
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ pul_mirror_config_files }}"
+  when: not pul_mirror_available
+
+- name: Refresh the apt cache
+  block:
+    - name: apt update (with retries)
+      ansible.builtin.apt:
+        update_cache: yes
+        cache_valid_time: 3600
+      register: aptu
+      retries: 5
+      delay: 3
+      until: aptu is succeeded
+  rescue:
+    # The probe passed but apt still could not fetch indexes, so treat the
+    # mirror as unusable for this run and finish from the upstream archive.
+    - name: Drop the PUL mirror after repeated apt failures
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ pul_mirror_config_files }}"
+
+    - name: Record that the PUL mirror was abandoned
+      ansible.builtin.set_fact:
+        pul_mirror_available: false
+
+    - name: apt update from the upstream archive only (with retries)
+      ansible.builtin.apt:
+        update_cache: yes
+      register: aptu_upstream
+      retries: 5
+      delay: 3
+      until: aptu_upstream is succeeded

--- a/ansible/roles/mirrors/tasks/main.yml
+++ b/ansible/roles/mirrors/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Configure preferred mirrors (Debian/Ubuntu)
-  import_tasks: debian.yml
-  when: ansible_os_family == 'Debian'
-
-- name: Configure preferred mirrors (RHEL/Rocky)
-  import_tasks: redhat.yml
-  when: ansible_os_family == 'RedHat'
+- name: "{{ mirrors_task_name }}"
+  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"
+  when: ansible_os_family in ['Debian', 'RedHat']

--- a/ansible/roles/mirrors/vars/main.yml
+++ b/ansible/roles/mirrors/vars/main.yml
@@ -6,3 +6,8 @@ mirrors_task_name: Configure the preferred package mirrors.
 pul_mirror_config_files:
   - /etc/apt/sources.list.d/00-pulmirror.list
   - /etc/apt/preferences.d/99-pulmirror.pref
+
+# Drop-ins we add only when the distribution does not configure the upstream
+# archive itself, and delete again when it does.
+pul_upstream_archive_filename: 20-ubuntu-archive
+pul_upstream_security_filename: 10-security

--- a/ansible/roles/mirrors/vars/main.yml
+++ b/ansible/roles/mirrors/vars/main.yml
@@ -1,0 +1,8 @@
+---
+mirrors_task_name: Configure the preferred package mirrors.
+
+# Files written only when the PUL mirror is usable; removed otherwise so apt is
+# never left pointing at a mirror it cannot reach.
+pul_mirror_config_files:
+  - /etc/apt/sources.list.d/00-pulmirror.list
+  - /etc/apt/preferences.d/99-pulmirror.pref

--- a/ansible/roles/security_firstboot/README.md
+++ b/ansible/roles/security_firstboot/README.md
@@ -54,6 +54,25 @@ These variables should be provided via cloud-init user-data and will be written 
 ### Cortex XDR
 - `CORTEX_XDR_TARBALL_URL` - URL to download the Cortex XDR installation tarball
 
+### Optional package source overrides
+
+Hosts without direct egress to the vendors can be pointed at a local mirror
+through the same env file, without rebuilding the image:
+
+- `BIGFIX_DEB_URL`, `BIGFIX_RPM_URL`, `BIGFIX_GPG_KEY_URL`
+- `RAPID7_DEB_URL`, `RAPID7_RPM_URL`, `RAPID7_RPM_PUBKEY`
+- `CORTEX_XDR_DEB_TARBALL_URL`, `CORTEX_XDR_RPM_TARBALL_URL`
+
+### Retry contract
+
+A download or install that fails is not an error: the installer logs the
+reason, exits 0 without writing its marker, and systemd runs it again on the
+next boot. Anything that aborts the script instead (an unguarded command
+under `set -e`) leaves the unit in `failed` forever, which monitoring reports
+as a down service on every boot. Route every network call through `pul_fetch`
+or `pul_rpm_key_import` and every package install through `pul_deb_install`
+or `pul_rpm_install`.
+
 ## Cortex XDR Installation Details
 
 The Cortex XDR agent installation follows the manual process documented in the vendor README:

--- a/ansible/roles/security_firstboot/defaults/main.yml
+++ b/ansible/roles/security_firstboot/defaults/main.yml
@@ -16,7 +16,7 @@ bigfix_rpm_url: "https://software.bigfix.com/download/bes/100/BESAgent-10.0.7.52
 bigfix_gpg_key_url: "https://software.bigfix.com/download/bes/95/RPM-GPG-KEY-BigFix-9-V2"
 
 rapid7_deb_url: "https://us.storage.endpoint.ingress.rapid7.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/rapid7_insight_agent_x64.deb"
-rapid7_rpm_url: "https://us.storage.endpoint.ingress.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/rapid7_insight_agent_x64.rpm"
+rapid7_rpm_url: "https://us.storage.endpoint.ingress.rapid7.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/rapid7_insight_agent_x64.rpm"
 rapid7_rpm_pubkey: "https://us.storage.endpoint.ingress.rapid7.com/com.rapid7.razor.public/endpoint/agent/latest/linux/x86_64/Rapid7_public_key.pub"
 
 # Palo Alto Cortex XDR (first-boot)

--- a/ansible/roles/security_firstboot/tasks/main.yml
+++ b/ansible/roles/security_firstboot/tasks/main.yml
@@ -26,6 +26,13 @@
     force: no
   tags: ["firstboot"]
 
+- name: Install shared first-boot installer helpers
+  ansible.builtin.template:
+    src: security-firstboot-lib.sh.j2
+    dest: /usr/local/lib/pul-security-firstboot.sh
+    mode: "0644"
+  tags: ["firstboot"]
+
 - name: Install first-boot helper scripts
   ansible.builtin.template:
     src: "{{ item.src }}"
@@ -46,6 +53,11 @@
       }
   tags: ["firstboot"]
 
+# All three installers fetch and install packages, so they must not run at the
+# same time as each other or as cloud-init's own package work: concurrent
+# apt/dpkg runs abort on the dpkg lock and can leave a half-installed package
+# that breaks every later upgrade. Chaining them after cloud-final keeps exactly
+# one package manager active at a time.
 - name: Install systemd units (oneshot; run once on first boot)
   ansible.builtin.copy:
     dest: "/etc/systemd/system/{{ item.name }}"
@@ -57,7 +69,7 @@
         [Unit]
         Description=BigFix first-boot installer
         Wants=network-online.target
-        After=network-online.target
+        After=network-online.target cloud-final.service
         ConditionPathExists=!/var/lib/security-firstboot/bigfix.done
         PartOf=cloud-final.service
 
@@ -74,7 +86,7 @@
         [Unit]
         Description=Rapid7 first-boot installer
         Wants=network-online.target
-        After=network-online.target
+        After=network-online.target cloud-final.service bigfix-firstboot.service
         ConditionPathExists=!/var/lib/security-firstboot/rapid7.done
         PartOf=cloud-final.service
 
@@ -91,7 +103,7 @@
         [Unit]
         Description=Palo Alto Cortex XDR first-boot installer
         Wants=network-online.target
-        After=network-online.target
+        After=network-online.target cloud-final.service rapid7-firstboot.service
         ConditionPathExists=!/var/lib/security-firstboot/cortex-xdr.done
         PartOf=cloud-final.service
 

--- a/ansible/roles/security_firstboot/templates/bigfix-firstboot.sh.j2
+++ b/ansible/roles/security_firstboot/templates/bigfix-firstboot.sh.j2
@@ -2,6 +2,9 @@
 # {{ ansible_managed | comment }}
 set -euo pipefail
 
+# shellcheck source=/dev/null
+source /usr/local/lib/pul-security-firstboot.sh
+
 STATE_DIR="/var/lib/security-firstboot"
 MARKER="${STATE_DIR}/bigfix.done"
 
@@ -47,14 +50,21 @@ fi
 # Install agent package (Debian/Ubuntu vs RHEL/Rocky)
 if command -v dpkg >/dev/null 2>&1; then
   echo "BigFix: installing DEB…"
-  curl -fsSL "{{ bigfix_deb_url }}" -o /tmp/BESAgent.deb
-  apt-get update -y || true
-  apt-get -y install /tmp/BESAgent.deb
+  BESAGENT_DEB="$(pul_pkg_cache)/BESAgent.deb"
+  curl -fsSL "{{ bigfix_deb_url }}" -o "$BESAGENT_DEB"
+  if ! pul_deb_install "$BESAGENT_DEB"; then
+    echo "BigFix: package install failed; will retry on next boot."
+    exit 0
+  fi
 else
   echo "BigFix: installing RPM…"
+  BESAGENT_RPM="$(pul_pkg_cache)/BESAgent.rpm"
   curl -fsSL "{{ bigfix_gpg_key_url }}" | rpm --import -
-  curl -fsSL "{{ bigfix_rpm_url }}" -o /tmp/BESAgent.rpm
-  dnf -y install /tmp/BESAgent.rpm || yum -y install /tmp/BESAgent.rpm
+  curl -fsSL "{{ bigfix_rpm_url }}" -o "$BESAGENT_RPM"
+  if ! pul_rpm_install "$BESAGENT_RPM"; then
+    echo "BigFix: package install failed; will retry on next boot."
+    exit 0
+  fi
 fi
 
 # Start & enable the service (name varies between distros)

--- a/ansible/roles/security_firstboot/templates/bigfix-firstboot.sh.j2
+++ b/ansible/roles/security_firstboot/templates/bigfix-firstboot.sh.j2
@@ -14,6 +14,13 @@ LEGACY_ETC_DIR="/etc/opt/BESClient"   # BigFix default lookup path
 # Env provided by systemd EnvironmentFile (/etc/pul/security-tools.env)
 : "${BIGFIX_MASTHEAD_URL:=}"
 
+# Package sources can be repointed at a local mirror without rebuilding the
+# image, which is what an environment with no direct egress to software.bigfix.com
+# needs.
+BIGFIX_DEB_URL="${BIGFIX_DEB_URL:-{{ bigfix_deb_url }}}"
+BIGFIX_RPM_URL="${BIGFIX_RPM_URL:-{{ bigfix_rpm_url }}}"
+BIGFIX_GPG_KEY_URL="${BIGFIX_GPG_KEY_URL:-{{ bigfix_gpg_key_url }}}"
+
 if [[ -f "$MARKER" ]]; then
   exit 0
 fi
@@ -37,10 +44,10 @@ if [[ -n "${BIGFIX_MASTHEAD_B64:-}" ]]; then
   echo "$BIGFIX_MASTHEAD_B64" | base64 -d > "$INSTALL_ROOT/actionsite.afxm"
   chmod 0600 "$INSTALL_ROOT/actionsite.afxm"
 elif [[ -n "$BIGFIX_MASTHEAD_URL" ]]; then
-  curl -fsSL --max-time 75 "$BIGFIX_MASTHEAD_URL" -o "$INSTALL_ROOT/actionsite.afxm" || {
-    echo "BigFix: cannot fetch masthead; skipping."
+  if ! pul_fetch "$BIGFIX_MASTHEAD_URL" "$INSTALL_ROOT/actionsite.afxm"; then
+    echo "BigFix: cannot fetch masthead; will retry on next boot."
     exit 0
-  }
+  fi
   chmod 0600 "$INSTALL_ROOT/actionsite.afxm"
 else
   echo "BigFix: no masthead provided; skipping."
@@ -51,7 +58,10 @@ fi
 if command -v dpkg >/dev/null 2>&1; then
   echo "BigFix: installing DEB…"
   BESAGENT_DEB="$(pul_pkg_cache)/BESAgent.deb"
-  curl -fsSL "{{ bigfix_deb_url }}" -o "$BESAGENT_DEB"
+  if ! pul_fetch "$BIGFIX_DEB_URL" "$BESAGENT_DEB"; then
+    echo "BigFix: cannot download agent; will retry on next boot."
+    exit 0
+  fi
   if ! pul_deb_install "$BESAGENT_DEB"; then
     echo "BigFix: package install failed; will retry on next boot."
     exit 0
@@ -59,8 +69,14 @@ if command -v dpkg >/dev/null 2>&1; then
 else
   echo "BigFix: installing RPM…"
   BESAGENT_RPM="$(pul_pkg_cache)/BESAgent.rpm"
-  curl -fsSL "{{ bigfix_gpg_key_url }}" | rpm --import -
-  curl -fsSL "{{ bigfix_rpm_url }}" -o "$BESAGENT_RPM"
+  if ! pul_rpm_key_import "$BIGFIX_GPG_KEY_URL"; then
+    echo "BigFix: cannot import signing key; will retry on next boot."
+    exit 0
+  fi
+  if ! pul_fetch "$BIGFIX_RPM_URL" "$BESAGENT_RPM"; then
+    echo "BigFix: cannot download agent; will retry on next boot."
+    exit 0
+  fi
   if ! pul_rpm_install "$BESAGENT_RPM"; then
     echo "BigFix: package install failed; will retry on next boot."
     exit 0

--- a/ansible/roles/security_firstboot/templates/cortex-xdr-firstboot.sh.j2
+++ b/ansible/roles/security_firstboot/templates/cortex-xdr-firstboot.sh.j2
@@ -2,6 +2,9 @@
 # {{ ansible_managed | comment }}
 set -euo pipefail
 
+# shellcheck source=/dev/null
+source /usr/local/lib/pul-security-firstboot.sh
+
 STATE_DIR="/var/lib/security-firstboot"
 MARKER="${STATE_DIR}/cortex-xdr.done"
 WORK_DIR="/tmp/cortex-xdr-install"
@@ -56,14 +59,16 @@ EOF
 chmod 0600 /etc/panw/cortex.conf
 echo "Cortex XDR: configuration written to /etc/panw/cortex.conf"
 
-# Install package (DEB or RPM based on OS)
+# Install package (DEB or RPM based on OS). The package is copied out of the
+# scratch dir first so it survives cleanup and stays available for repairs.
 installed=false
 if command -v dpkg >/dev/null 2>&1; then
   CORTEX_DEB=$(find . -name "*.deb" -type f | head -n1)
   if [[ -n "$CORTEX_DEB" && -f "$CORTEX_DEB" ]]; then
     echo "Cortex XDR: installing DEB package $CORTEX_DEB..."
-    apt-get update -y || true
-    if apt-get -y install "$CORTEX_DEB"; then
+    CORTEX_CACHED="$(pul_pkg_cache)/$(basename "$CORTEX_DEB")"
+    cp -f "$CORTEX_DEB" "$CORTEX_CACHED"
+    if pul_deb_install "$CORTEX_CACHED"; then
       installed=true
     fi
   else
@@ -73,7 +78,9 @@ else
   CORTEX_RPM=$(find . -name "*.rpm" -type f | head -n1)
   if [[ -n "$CORTEX_RPM" && -f "$CORTEX_RPM" ]]; then
     echo "Cortex XDR: installing RPM package $CORTEX_RPM..."
-    if dnf -y install "$CORTEX_RPM" 2>/dev/null || yum -y install "$CORTEX_RPM"; then
+    CORTEX_CACHED="$(pul_pkg_cache)/$(basename "$CORTEX_RPM")"
+    cp -f "$CORTEX_RPM" "$CORTEX_CACHED"
+    if pul_rpm_install "$CORTEX_CACHED"; then
       installed=true
     fi
   else

--- a/ansible/roles/security_firstboot/templates/rapid7-firstboot.sh.j2
+++ b/ansible/roles/security_firstboot/templates/rapid7-firstboot.sh.j2
@@ -2,6 +2,9 @@
 # {{ ansible_managed | comment }}
 set -euo pipefail
 
+# shellcheck source=/dev/null
+source /usr/local/lib/pul-security-firstboot.sh
+
 STATE_DIR="/var/lib/security-firstboot"
 MARKER="${STATE_DIR}/rapid7.done"
 mkdir -p "$STATE_DIR"
@@ -25,16 +28,19 @@ installed=false
 if command -v dpkg >/dev/null 2>&1; then
   if [[ -n "$R7_DEB_URL" ]]; then
     echo "Rapid7: installing DEB…"
-    curl -fsSL "$R7_DEB_URL" -o /tmp/rapid7.deb
-    apt-get update -y || true
-    apt-get -y install /tmp/rapid7.deb && installed=true || true
+    R7_DEB="$(pul_pkg_cache)/rapid7-insight-agent.deb"
+    if curl -fsSL "$R7_DEB_URL" -o "$R7_DEB" && pul_deb_install "$R7_DEB"; then
+      installed=true
+    fi
   fi
 else
   if [[ -n "$R7_RPM_URL" ]]; then
     echo "Rapid7: installing RPM…"
+    R7_RPM="$(pul_pkg_cache)/rapid7-insight-agent.rpm"
     curl -fsSL "$R7_RPM_PUBKEY" | rpm --import -
-    curl -fsSL "$R7_RPM_URL" -o /tmp/rapid7.rpm
-    (dnf -y install /tmp/rapid7.rpm || yum -y install /tmp/rapid7.rpm) && installed=true || true
+    if curl -fsSL "$R7_RPM_URL" -o "$R7_RPM" && pul_rpm_install "$R7_RPM"; then
+      installed=true
+    fi
   fi
 fi
 

--- a/ansible/roles/security_firstboot/templates/rapid7-firstboot.sh.j2
+++ b/ansible/roles/security_firstboot/templates/rapid7-firstboot.sh.j2
@@ -15,7 +15,7 @@ mkdir -p "$STATE_DIR"
 # Allow overrides via env; fall back to template defaults
 R7_DEB_URL="${RAPID7_DEB_URL:-{{ rapid7_deb_url }}}"
 R7_RPM_URL="${RAPID7_RPM_URL:-{{ rapid7_rpm_url }}}"
-R7_RPM_PUBKEY="{{ rapid7_rpm_pubkey }}"
+R7_RPM_PUBKEY="${RAPID7_RPM_PUBKEY:-{{ rapid7_rpm_pubkey }}}"
 
 [[ -f "$MARKER" ]] && exit 0
 
@@ -29,7 +29,7 @@ if command -v dpkg >/dev/null 2>&1; then
   if [[ -n "$R7_DEB_URL" ]]; then
     echo "Rapid7: installing DEB…"
     R7_DEB="$(pul_pkg_cache)/rapid7-insight-agent.deb"
-    if curl -fsSL "$R7_DEB_URL" -o "$R7_DEB" && pul_deb_install "$R7_DEB"; then
+    if pul_fetch "$R7_DEB_URL" "$R7_DEB" && pul_deb_install "$R7_DEB"; then
       installed=true
     fi
   fi
@@ -37,8 +37,9 @@ else
   if [[ -n "$R7_RPM_URL" ]]; then
     echo "Rapid7: installing RPM…"
     R7_RPM="$(pul_pkg_cache)/rapid7-insight-agent.rpm"
-    curl -fsSL "$R7_RPM_PUBKEY" | rpm --import -
-    if curl -fsSL "$R7_RPM_URL" -o "$R7_RPM" && pul_rpm_install "$R7_RPM"; then
+    if pul_rpm_key_import "$R7_RPM_PUBKEY" &&
+      pul_fetch "$R7_RPM_URL" "$R7_RPM" &&
+      pul_rpm_install "$R7_RPM"; then
       installed=true
     fi
   fi
@@ -53,7 +54,7 @@ if [[ "$installed" == true ]]; then
   touch "$MARKER"
   echo "Rapid7: installed."
 else
-  echo "Rapid7: no package URL available or install failed; skipping."
+  echo "Rapid7: no package URL available or install failed; will retry on next boot."
 fi
 
 exit 0

--- a/ansible/roles/security_firstboot/templates/security-firstboot-lib.sh.j2
+++ b/ansible/roles/security_firstboot/templates/security-firstboot-lib.sh.j2
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# {{ ansible_managed | comment }}
+#
+# Shared helpers for the security first-boot installers.
+#
+# These run unattended on a machine that cloud-init and the distribution's own
+# update timers are still working on, so every package operation has to survive a
+# busy package manager and must never leave the package database in a state that
+# breaks later upgrades.
+
+# Downloaded packages stay here instead of /tmp: if an install is interrupted,
+# the package manager needs the original archive to repair the package, and /tmp
+# is wiped on reboot ("needs to be reinstalled, but I can't find an archive").
+PUL_PKG_CACHE="${PUL_PKG_CACHE:-/var/cache/pul/security-firstboot}"
+
+# Seconds to wait for another process to release the dpkg/apt locks.
+PUL_LOCK_TIMEOUT="${PUL_LOCK_TIMEOUT:-600}"
+
+pul_pkg_cache() {
+  mkdir -p "$PUL_PKG_CACHE"
+  chmod 0700 "$PUL_PKG_CACHE"
+  printf '%s' "$PUL_PKG_CACHE"
+}
+
+pul_apt() {
+  DEBIAN_FRONTEND=noninteractive apt-get \
+    -o DPkg::Lock::Timeout="$PUL_LOCK_TIMEOUT" \
+    -o Dpkg::Options::=--force-confdef \
+    -o Dpkg::Options::=--force-confold \
+    "$@"
+}
+
+# Install a local .deb. Returns non-zero on failure, having backed the package
+# out so that unrelated apt commands still work afterwards.
+pul_deb_install() {
+  local deb="$1" pkg=""
+
+  # Heal a previous interrupted install; otherwise every apt call refuses to run.
+  dpkg --configure -a || true
+
+  pul_apt -y update || true
+  if pul_apt -y install "$deb"; then
+    return 0
+  fi
+
+  pkg="$(dpkg-deb -f "$deb" Package 2>/dev/null || true)"
+  if [[ -n "$pkg" ]]; then
+    echo "pul: backing out failed install of ${pkg}" >&2
+    pul_apt -y remove --purge "$pkg" \
+      || dpkg --remove --force-remove-reinstreq "$pkg" \
+      || true
+  fi
+  dpkg --configure -a || true
+  return 1
+}
+
+# Install a local .rpm.
+pul_rpm_install() {
+  local rpm="$1"
+  dnf -y install "$rpm" 2>/dev/null || yum -y install "$rpm"
+}

--- a/ansible/roles/security_firstboot/templates/security-firstboot-lib.sh.j2
+++ b/ansible/roles/security_firstboot/templates/security-firstboot-lib.sh.j2
@@ -16,10 +16,49 @@ PUL_PKG_CACHE="${PUL_PKG_CACHE:-/var/cache/pul/security-firstboot}"
 # Seconds to wait for another process to release the dpkg/apt locks.
 PUL_LOCK_TIMEOUT="${PUL_LOCK_TIMEOUT:-600}"
 
+# Bounded so a blocked or proxied egress path cannot stall the boot, and so a
+# single dropped connection does not lose the whole install.
+PUL_CONNECT_TIMEOUT="${PUL_CONNECT_TIMEOUT:-15}"
+PUL_MAX_TIME="${PUL_MAX_TIME:-300}"
+PUL_FETCH_ATTEMPTS="${PUL_FETCH_ATTEMPTS:-3}"
+
 pul_pkg_cache() {
   mkdir -p "$PUL_PKG_CACHE"
   chmod 0700 "$PUL_PKG_CACHE"
   printf '%s' "$PUL_PKG_CACHE"
+}
+
+# Download a URL to a file, retrying a few times. Returns non-zero instead of
+# aborting so the caller can log, leave its marker unwritten and let systemd
+# retry the unit on the next boot rather than parking it in "failed".
+pul_fetch() {
+  local url="$1" dest="$2" attempt=1
+  while true; do
+    if curl -fsSL --connect-timeout "$PUL_CONNECT_TIMEOUT" \
+      --max-time "$PUL_MAX_TIME" "$url" -o "$dest"; then
+      return 0
+    fi
+    if [[ "$attempt" -ge "$PUL_FETCH_ATTEMPTS" ]]; then
+      break
+    fi
+    sleep $((attempt * 5))
+    attempt=$((attempt + 1))
+  done
+  rm -f "$dest"
+  echo "pul: download failed after ${PUL_FETCH_ATTEMPTS} attempts: ${url}" >&2
+  return 1
+}
+
+# Import an RPM signing key. The key is downloaded to a file first rather than
+# piped into "rpm --import -": when the download fails, rpm reads an empty
+# stdin and exits 1, and with "set -o pipefail" that becomes the status of the
+# whole pipeline, so "set -e" kills the installer and the unit stays failed on
+# every later boot.
+pul_rpm_key_import() {
+  local url="$1" key
+  key="$(pul_pkg_cache)/$(basename "$url").key"
+  pul_fetch "$url" "$key" || return 1
+  rpm --import "$key"
 }
 
 pul_apt() {

--- a/builds/linux/ubuntu/resolute-cloudimg.pkr.hcl
+++ b/builds/linux/ubuntu/resolute-cloudimg.pkr.hcl
@@ -1,0 +1,815 @@
+// © Broadcom. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+// borrowed heavily from https://vmware.github.io/packer-examples-for-vsphere/
+// Packer + QEMU using Ubuntu cloud image + cloud-init (NoCloud seed)
+
+packer {
+  required_version = ">= 1.12.0"
+  required_plugins {
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = ">= 1.1.0"
+    }
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = ">= 1.1.2"
+    }
+    git = {
+      source  = "github.com/ethanmdavidson/git"
+      version = ">= 0.6.3"
+    }
+  }
+}
+
+/////////////////////////////
+// Variables (separate these once successful?)     //
+/////////////////////////////
+
+// Naming / OS metadata
+variable "vm_guest_os_family" {
+  type        = string
+  default     = "linux"
+  description = "OS family for naming (e.g., linux)."
+}
+
+variable "vm_guest_os_name" {
+  type        = string
+  default     = "ubuntu"
+  description = "OS name for naming (e.g., ubuntu)."
+}
+
+variable "vm_guest_os_version" {
+  type        = string
+  default     = "26.04-lts"
+  description = "OS version string for naming (e.g., 26.04-lts)."
+}
+
+variable "vm_guest_os_type" {
+  type        = string
+  default     = "ubuntu64Guest"
+  description = "Informational guest type label (for manifest)."
+}
+
+// Firmware label for manifest only (qemu will use default unless we wire EFI vars)
+variable "vm_firmware" {
+  type        = string
+  default     = "efi-secure"
+  description = "Virtual firmware: 'efi', 'efi-secure', or 'bios'."
+}
+
+// Cloud image "url" (still named iso_* to match builder inputs)
+variable "iso_filename" {
+  type        = string
+  default     = "resolute-server-cloudimg-amd64.img"
+  description = "Default local image under ./isos when iso_url not provided."
+}
+
+variable "iso_url" {
+  type        = string
+  default     = "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img"
+  description = "file:///... or https://... to a cloud image (QCOW2). Leave empty to use ./isos/<iso_filename>."
+}
+
+variable "iso_checksum" {
+  type        = string
+  default     = "sha256:117816726abbdefc5ef3e38902e81a76f1c76c3610e709999d0885f9d5d9b477"
+  description = "Checksum for the cloud image (e.g., sha256:...). See Ubuntu release checksums."
+}
+
+// QEMU knobs
+variable "qemu_accelerator" {
+  type        = string
+  default     = "tcg"
+  description = "Acceleration: kvm (Linux), hvf (macOS same-arch), or tcg/none (software)."
+}
+
+variable "qemu_headless" {
+  type        = bool
+  default     = true
+  description = "Run QEMU headless."
+}
+
+variable "qemu_binary" {
+  type        = string
+  default     = null
+  description = "Optional override path to qemu-system-x86_64."
+}
+
+variable "qemu_machine_type" {
+  type        = string
+  default     = null
+  description = "Optional machine type (e.g., q35)."
+}
+
+variable "qemu_disk_format" {
+  type        = string
+  default     = "qcow2"
+  description = "Disk format for builder output (qcow2 recommended)."
+}
+
+variable "qemu_disk_interface" {
+  type        = string
+  default     = "virtio"
+  description = "Disk interface: virtio, scsi, ide."
+}
+
+variable "qemu_net_device" {
+  type        = string
+  default     = "virtio-net"
+  description = "NIC model: virtio-net, e1000, rtl8139."
+}
+
+// VM resources
+variable "vm_cpu_count" {
+  type        = number
+  default     = 2
+  description = "vCPUs."
+}
+
+variable "vm_cpu_cores" {
+  type        = number
+  default     = 1
+  description = "Cores per socket (manifest only)."
+}
+
+variable "vm_mem_size" {
+  type        = number
+  default     = 8192
+  description = "RAM (MB)."
+}
+
+variable "vm_disk_size" {
+  type        = number
+  default     = 35840
+  description = "Disk size (MB)."
+}
+
+// Guest net/storage for templates
+variable "vm_network_device" {
+  type        = string
+  default     = "ens3"
+  description = "Guest NIC name (e.g., ens3 for virtio)."
+}
+
+variable "vm_ip_address" {
+  type        = string
+  default     = null
+  description = "Static IP (or null for DHCP)."
+}
+
+variable "vm_ip_netmask" {
+  type        = number
+  default     = null
+  description = "CIDR netmask (e.g., 24) or null."
+}
+
+variable "vm_ip_gateway" {
+  type        = string
+  default     = null
+  description = "Gateway or null."
+}
+
+variable "vm_dns_list" {
+  type        = list(string)
+  default     = []
+  description = "Nameservers."
+}
+
+variable "vm_disk_device" {
+  type        = string
+  default     = "vda"
+  description = "Primary disk device inside guest (virtio -> vda)."
+}
+
+variable "vm_disk_use_swap" {
+  type        = bool
+  default     = true
+  description = "Whether to use swap partition."
+}
+
+variable "vm_disk_partitions" {
+  type = list(object({
+    name = string
+    size = number
+    format = object({
+      label  = string
+      fstype = string
+    })
+    mount = object({
+      path    = string
+      options = string
+    })
+    volume_group = string
+  }))
+  default     = []
+  description = "Partition scheme for the primary disk."
+}
+
+variable "vm_disk_lvm" {
+  type = list(object({
+    name = string
+    partitions = list(object({
+      name = string
+      size = number
+      format = object({
+        label  = string
+        fstype = string
+      })
+      mount = object({
+        path    = string
+        options = string
+      })
+    }))
+  }))
+  default     = []
+  description = "Optional LVM layout."
+}
+
+// ova variables
+// gzip the qcow2 after build
+variable "compress_qcow2" {
+  type    = bool
+  default = false
+}
+
+// write a minimal OVF + .mf next to the VMDK
+variable "export_ovf" {
+  type    = bool
+  default = false
+}
+
+// tar OVF set into a single .ova
+variable "pack_ova" {
+  type    = bool
+  default = false
+}
+
+// Cloud-init transport
+variable "common_data_source" {
+  type        = string
+  default     = "disk"
+  description = "Provisioning data source: 'http' or 'disk'. (NoCloud as attached seed disk by default)"
+}
+
+variable "common_http_ip" {
+  type        = string
+  default     = null
+  description = "Bind IP for packer's HTTP server (null=all interfaces)."
+}
+
+variable "common_http_port_min" {
+  type        = number
+  default     = 8800
+  description = "HTTP server port range start."
+}
+
+variable "common_http_port_max" {
+  type        = number
+  default     = 8900
+  description = "HTTP server port range end."
+}
+
+// Auth / communicator
+variable "build_username" {
+  type        = string
+  default     = "packer"
+  description = "SSH user created by cloud-init user-data."
+}
+
+variable "build_password" {
+  type        = string
+  default     = "packer"
+  sensitive   = true
+  description = "Password for build user."
+}
+
+variable "build_password_encrypted" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "Encrypted password for the installer identity (mkpasswd -m sha-512)."
+}
+
+variable "build_key" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "SSH public key for build user."
+}
+
+variable "communicator_port" {
+  type        = number
+  default     = 22
+  description = "SSH port."
+}
+
+variable "communicator_timeout" {
+  type        = string
+  default     = "30m"
+  description = "SSH timeout."
+}
+
+variable "ansible_username" {
+  type        = string
+  default     = "packer"
+  sensitive   = true
+  description = "SSH user for Ansible (same as build_username)."
+}
+
+variable "ansible_key" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "SSH public key for Ansible"
+}
+
+variable "vm_guest_os_language" {
+  type        = string
+  default     = "en_US"
+  description = "Locale."
+}
+
+variable "vm_guest_os_keyboard" {
+  type        = string
+  default     = "us"
+  description = "Keyboard layout."
+}
+
+variable "vm_guest_os_timezone" {
+  type        = string
+  default     = "UTC"
+  description = "Timezone."
+}
+
+variable "vm_guest_os_cloudinit" {
+  type        = bool
+  default     = true
+  description = "Expose flag to Ansible."
+}
+
+variable "additional_packages" {
+  type        = list(string)
+  default     = []
+  description = "Extra packages to install."
+}
+
+// Manifest-only toggles
+variable "vm_network_card" {
+  type        = string
+  default     = "virtio-net"
+  description = "Manifest-only label for NIC type."
+}
+
+variable "vm_disk_thin_provisioned" {
+  type        = bool
+  default     = true
+  description = "Manifest-only flag mirroring vSphere template."
+}
+
+// Timeouts
+variable "vm_boot_wait" {
+  type        = string
+  default     = "3s"
+  description = "Time to wait before typing boot commands (unused in cloudimg path)."
+}
+
+variable "common_shutdown_timeout" {
+  type        = string
+  default     = "20m"
+  description = "Time to wait for shutdown."
+}
+
+// HCP Packer (optional)
+variable "common_hcp_packer_registry_enabled" {
+  type    = bool
+  default = false
+}
+
+// security_role
+variable "prepare_security_firstboot" {
+  type    = bool
+  default = true
+}
+
+variable "BIGFIX_MASTHEAD_URL" {
+  type    = string
+  default = env("BIGFIX_MASTHEAD_URL")
+}
+
+variable "RAPID7_TOKEN" {
+  type    = string
+  default = env("RAPID7_TOKEN")
+}
+
+variable "RAPID7_ATTRIBUTES" {
+  type    = string
+  default = env("RAPID7_ATTRIBUTES")
+}
+
+variable "CORTEX_XDR_DEB_TARBALL_URL" {
+  type    = string
+  default = env("CORTEX_XDR_DEB_TARBALL_URL")
+}
+
+variable "CORTEX_XDR_DISTRIBUTION_ID" {
+  type      = string
+  default   = env("CORTEX_XDR_DISTRIBUTION_ID")
+  sensitive = true
+}
+
+variable "CORTEX_XDR_DISTRIBUTION_SERVER" {
+  type    = string
+  default = env("CORTEX_XDR_DISTRIBUTION_SERVER")
+}
+
+
+////////////////////
+// Data & Locals  //
+////////////////////
+
+data "git-repository" "cwd" {}
+
+locals {
+  build_by          = "Built by: HashiCorp Packer ${packer.version}"
+  build_date        = formatdate("YYYY-MM-DD hh:mm ZZZ", timestamp())
+  build_timestamp   = formatdate("YYYYMMDD-HHmmss", timestamp())
+  build_description = "Built on: ${local.build_date}\n${local.build_by}"
+
+  manifest_date   = formatdate("YYYY-MM-DD hh:mm:ss", timestamp())
+  manifest_path   = "${abspath(path.root)}/../../../manifests/"
+  manifest_output = "${local.manifest_path}${local.manifest_date}.json"
+
+  vm_name    = "${var.vm_guest_os_family}-${var.vm_guest_os_name}-${replace(var.vm_guest_os_version, ".", "-")}-${local.build_timestamp}"
+  output_dir = "${abspath(path.root)}/../../../artifacts/qemu/${local.vm_name}"
+
+  // Resolve local cloud image if iso_url not provided
+  iso_url_effective = var.iso_url != "" ? var.iso_url : "file://${abspath(path.root)}/isos/${var.iso_filename}"
+
+  // ova
+  qcow2_artifact = var.compress_qcow2 ? "${local.vm_name}.qcow2.gz" : "${local.vm_name}.qcow2"
+
+  user_data_vars = {
+    vm_guest_os_name         = var.vm_guest_os_name
+    build_username           = var.build_username
+    build_password           = var.build_password
+    build_password_encrypted = var.build_password_encrypted
+    build_key                = var.build_key
+    vm_guest_os_language     = var.vm_guest_os_language
+    vm_guest_os_keyboard     = var.vm_guest_os_keyboard
+    vm_guest_os_timezone     = var.vm_guest_os_timezone
+    network = templatefile("${abspath(path.root)}/data/network.pkrtpl.hcl", {
+      device  = var.vm_network_device
+      ip      = var.vm_ip_address
+      netmask = var.vm_ip_netmask
+      gateway = var.vm_ip_gateway
+      dns     = var.vm_dns_list
+    })
+    storage = templatefile("${abspath(path.root)}/data/storage.pkrtpl.hcl", {
+      device     = var.vm_disk_device
+      swap       = var.vm_disk_use_swap
+      partitions = var.vm_disk_partitions
+      lvm        = var.vm_disk_lvm
+    })
+    additional_packages = var.additional_packages
+
+    # the security first-boot vars
+    BIGFIX_MASTHEAD_URL            = var.BIGFIX_MASTHEAD_URL
+    RAPID7_TOKEN                   = var.RAPID7_TOKEN
+    RAPID7_ATTRIBUTES              = var.RAPID7_ATTRIBUTES
+    CORTEX_XDR_DEB_TARBALL_URL     = var.CORTEX_XDR_DEB_TARBALL_URL
+    CORTEX_XDR_DISTRIBUTION_ID     = var.CORTEX_XDR_DISTRIBUTION_ID
+    CORTEX_XDR_DISTRIBUTION_SERVER = var.CORTEX_XDR_DISTRIBUTION_SERVER
+  }
+
+  // cloud-init seed (NoCloud)
+  data_source_content = {
+    "/meta-data" = file("${abspath(path.root)}/data/meta-data")
+  "/user-data" = templatefile("${abspath(path.root)}/data/user-data.pkrtpl.hcl", local.user_data_vars) }
+
+  // If we switch to HTTP seed instead of a seed disk:
+  data_source_command = var.common_data_source == "http" ? "ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"" : "ds=\"nocloud\""
+
+  bucket_name        = replace("${var.vm_guest_os_family}-${var.vm_guest_os_name}-${var.vm_guest_os_version}", ".", "")
+  bucket_description = "${var.vm_guest_os_family} ${var.vm_guest_os_name} ${var.vm_guest_os_version}"
+}
+
+//////////////////////////
+// QEMU Build (cloudimg)
+//////////////////////////
+
+source "qemu" "linux-ubuntu-cloudimg" {
+  // Point at the cloud image (QCOW2)
+  iso_url      = local.iso_url_effective
+  iso_checksum = var.iso_checksum
+  disk_image   = true // treat iso_url as a bootable image
+
+  // QEMU basics
+  accelerator  = var.qemu_accelerator
+  headless     = var.qemu_headless
+  qemu_binary  = var.qemu_binary
+  machine_type = var.qemu_machine_type
+  // firmware  = local.qemu_firmware // this is a mess because of arm and intel archs avoid these dragons
+
+  // Resources (Packer can resize a cloud image when disk_image=true)
+  cpus           = var.vm_cpu_count
+  memory         = var.vm_mem_size
+  disk_size      = var.vm_disk_size
+  format         = var.qemu_disk_format
+  disk_interface = var.qemu_disk_interface
+
+  // Network device
+  net_device = var.qemu_net_device
+
+  // Output
+  output_directory = local.output_dir
+
+  // No installer → no boot_command needed.
+  // Attach NoCloud data as a seed disk:
+  cd_content = var.common_data_source == "disk" ? local.data_source_content : null
+  cd_label   = var.common_data_source == "disk" ? "cidata" : null
+
+  // Serve the same content via ephemeral HTTP
+  http_content      = var.common_data_source == "http" ? local.data_source_content : null
+  http_bind_address = var.common_data_source == "http" ? var.common_http_ip : null
+  http_port_min     = var.common_data_source == "http" ? var.common_http_port_min : null
+  http_port_max     = var.common_data_source == "http" ? var.common_http_port_max : null
+
+  // Communicator
+  communicator = "ssh"
+  ssh_username = var.build_username
+  ssh_password = var.build_password
+  ssh_port     = var.communicator_port
+  ssh_timeout  = var.communicator_timeout
+
+  // Shutdown (cloud-init can also do power_state; this is fine)
+  shutdown_command = "echo '${var.build_password}' | sudo -S -E shutdown -P now"
+  shutdown_timeout = var.common_shutdown_timeout
+}
+
+//////////////
+// Build     //
+//////////////
+
+build {
+  sources = ["source.qemu.linux-ubuntu-cloudimg"]
+
+  // Reuse Ansible flow
+  provisioner "ansible" {
+    user                   = var.build_username
+    galaxy_file            = "${abspath(path.root)}/../../../ansible/linux-requirements.yml"
+    galaxy_force_with_deps = true
+    playbook_file          = "${abspath(path.root)}/../../../ansible/linux-playbook.yml"
+    roles_path             = "${abspath(path.root)}/../../../ansible/roles"
+    ansible_env_vars = [
+      "ANSIBLE_CONFIG=${abspath(path.root)}/../../../ansible/ansible.cfg",
+      "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
+    ]
+    extra_arguments = [
+      "--extra-vars", "display_skipped_hosts=false",
+      "--extra-vars", "build_username=${var.build_username}",
+      "--extra-vars", "build_key='${var.build_key}'",
+      "--extra-vars", "ansible_username=${var.ansible_username}",
+      "--extra-vars", "ansible_key='${var.ansible_key}'",
+      "--extra-vars", "enable_cloudinit=${var.vm_guest_os_cloudinit}",
+      "--extra-vars", "cleanup_final_image=true",
+      "--extra-vars", "prepare_security_firstboot=${var.prepare_security_firstboot}",
+      "--forks", "1"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo userdel -r packer 2>/dev/null || true",
+      "sudo userdel -r ubuntu 2>/dev/null || true",
+    ]
+    execute_command = "echo '${var.build_password}' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+  }
+
+
+  post-processor "manifest" {
+    output     = local.manifest_output
+    strip_path = true
+    strip_time = true
+    custom_data = {
+      ansible_username         = var.ansible_username
+      build_username           = var.build_username
+      build_date               = local.build_date
+      build_timestamp          = local.build_timestamp
+      common_data_source       = var.common_data_source
+      vm_cpu_cores             = var.vm_cpu_cores
+      vm_cpu_count             = var.vm_cpu_count
+      vm_disk_size             = var.vm_disk_size
+      vm_disk_thin_provisioned = var.vm_disk_thin_provisioned
+      vm_firmware              = var.vm_firmware
+      vm_guest_os_type         = var.vm_guest_os_type
+      vm_mem_size              = var.vm_mem_size
+      vm_network_card          = var.vm_network_card
+      qemu_accelerator         = var.qemu_accelerator
+      qemu_disk_format         = var.qemu_disk_format
+      qemu_disk_interface      = var.qemu_disk_interface
+      qemu_net_device          = var.qemu_net_device
+      iso_url                  = local.iso_url_effective
+    }
+  }
+
+  // Convert QCOW2 → VMDK/VHD
+  post-processor "shell-local" {
+    inline = [<<-EOT
+      set -euo pipefail
+      D='${local.output_dir}'
+      B='${local.vm_name}'
+
+      # Find the source image produced by the builder
+      SRC="$(ls -1 "$D"/*.qcow2 2>/dev/null | head -n1 || true)"
+      if [ -z "$SRC" ]; then SRC="$(ls -1 "$D"/*.img 2>/dev/null | head -n1 || true)"; fi
+      if [ -z "$SRC" ]; then SRC="$(ls -1 "$D"/packer-* 2>/dev/null | head -n1 || true)"; fi
+      if [ -z "$SRC" ]; then SRC="$(find "$D" -type f -size +100M -print0 | xargs -0 ls -1S 2>/dev/null | head -n1 || true)"; fi
+      if [ -z "$SRC" ]; then echo "Could not locate source disk image in $D" >&2; exit 1; fi
+
+      qemu-img info "$SRC" || true
+
+      # Convert to target formats for publishing
+      qemu-img convert -p -O qcow2 "$SRC" "$D/$B.qcow2"
+      qemu-img convert -p -O vmdk -o subformat=streamOptimized "$SRC" "$D/$B.vmdk"
+      qemu-img convert -p -O vpc  -o subformat=dynamic        "$SRC" "$D/$B.vhd"
+
+      # gzip qcow2 (after we've created it)
+      if [ "${var.compress_qcow2}" = "true" ]; then
+        gzip -f -9 "$D/$B.qcow2"
+      fi
+
+      # OVF/OVA export
+      if [ "${var.export_ovf}" = "true" ]; then
+        VMDK="$D/$B.vmdk"
+        OVF="$D/$B.ovf"
+        MF="$D/$B.mf"
+
+        # Pull virtual size in bytes from the VMDK we just created
+        DISK_BYTES=$(qemu-img info "$VMDK" | awk '/virtual size/ {match($0, /\(([0-9]+) bytes\)/, a); print a[1]}')
+
+        # Actual VMDK file size in bytes (BSD + GNU stat)
+        FILE_BYTES=$(stat -f%z "$VMDK" 2>/dev/null || stat -c%s "$VMDK")
+
+        cat > "$OVF" <<'OVF'
+  <?xml version="1.0" encoding="UTF-8"?>
+  <ovf:Envelope
+    xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
+    xmlns:vmw="http://www.vmware.com/schema/ovf"
+    xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+    xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
+    ovf:version="1.0">
+
+    <ovf:References>
+      <ovf:File ovf:id="file1" ovf:href="__B__.vmdk" ovf:size="__FILE_BYTES__"/>
+    </ovf:References>
+
+    <ovf:NetworkSection>
+      <ovf:Info>Logical networks used in the package</ovf:Info>
+      <ovf:Network ovf:name="__NETWORK__"/>
+    </ovf:NetworkSection>
+
+    <ovf:DiskSection>
+      <ovf:Info>Virtual disk information</ovf:Info>
+      <ovf:Disk ovf:diskId="vmdisk1" ovf:fileRef="file1"
+                ovf:capacity="__DISK_BYTES__"
+                ovf:capacityAllocationUnits="byte"
+                ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+    </ovf:DiskSection>
+
+    <ovf:VirtualSystem ovf:id="__B__">
+      <ovf:Info>__OS_NAME__ __OS_VER__</ovf:Info>
+
+      <ovf:OperatingSystemSection ovf:id="101" vmw:osType="__GUEST_ID__">
+        <ovf:Info>Guest OS type</ovf:Info>
+        <ovf:Description>__OS_DESC__</ovf:Description>
+      </ovf:OperatingSystemSection>
+
+      <ovf:VirtualHardwareSection>
+        <ovf:Info>Virtual hardware requirements</ovf:Info>
+
+        <ovf:System>
+            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+            <vssd:InstanceID>0</vssd:InstanceID>
+            <vssd:VirtualSystemIdentifier>__B__</vssd:VirtualSystemIdentifier>
+            <vssd:VirtualSystemType>vmx-14</vssd:VirtualSystemType>
+          </ovf:System>
+
+        <ovf:Item>
+          <rasd:Description>Number of Virtual CPUs</rasd:Description>
+          <rasd:ElementName>__CPU__ virtual CPU(s)</rasd:ElementName>
+          <rasd:InstanceID>1</rasd:InstanceID>
+          <rasd:ResourceType>3</rasd:ResourceType>
+          <rasd:VirtualQuantity>__CPU__</rasd:VirtualQuantity>
+        </ovf:Item>
+
+        <ovf:Item>
+          <rasd:Description>Memory Size</rasd:Description>
+          <rasd:ElementName>__MEM__MB of memory</rasd:ElementName>
+          <rasd:InstanceID>2</rasd:InstanceID>
+          <rasd:ResourceType>4</rasd:ResourceType>
+          <rasd:VirtualQuantity>__MEM__</rasd:VirtualQuantity>
+          <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        </ovf:Item>
+
+        <ovf:Item>
+          <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+          <rasd:InstanceID>3</rasd:InstanceID>
+          <rasd:ResourceType>6</rasd:ResourceType>
+          <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+          <rasd:BusNumber>0</rasd:BusNumber>
+          <rasd:Address>0</rasd:Address>
+        </ovf:Item>
+
+        <ovf:Item>
+          <rasd:ElementName>Hard disk 1</rasd:ElementName>
+          <rasd:InstanceID>4</rasd:InstanceID>
+          <rasd:ResourceType>17</rasd:ResourceType>
+          <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+          <rasd:Parent>3</rasd:Parent>
+          <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        </ovf:Item>
+
+        <ovf:Item>
+          <rasd:ElementName>Network adapter 1</rasd:ElementName>
+          <rasd:InstanceID>5</rasd:InstanceID>
+          <rasd:ResourceType>10</rasd:ResourceType>
+          <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+          <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+          <rasd:Connection>__NETWORK__</rasd:Connection>
+        </ovf:Item>
+
+      </ovf:VirtualHardwareSection>
+    </ovf:VirtualSystem>
+  </ovf:Envelope>
+  OVF
+
+        # sed helper (BSD/GNU safe) + escaper
+        _inplace_sed() { if sed --version >/dev/null 2>&1; then sed -i "$1" "$2"; else sed -i '' "$1" "$2"; fi; }
+        esc() { printf '%s' "$1" | sed 's/[&/]/\\&/g'; }
+
+        NETWORK_NAME="$${NETWORK_NAME:-VM Network}"
+        GUEST_ID="$${GUEST_ID:-${var.vm_guest_os_type}}"
+        OS_NAME="$${OS_NAME:-${var.vm_guest_os_name}}"
+        OS_VER="$${OS_VER:-${var.vm_guest_os_version}}"
+        OS_DESC="$${OS_DESC:-${var.vm_guest_os_name} ${var.vm_guest_os_version}}"
+
+        _inplace_sed "s/__B__/$(esc "$B")/g" "$OVF"
+        _inplace_sed "s/__DISK_BYTES__/$(esc "$DISK_BYTES")/g" "$OVF"
+        _inplace_sed "s/__FILE_BYTES__/$(esc "$FILE_BYTES")/g" "$OVF"
+        _inplace_sed "s/__NETWORK__/$(esc "$NETWORK_NAME")/g" "$OVF"
+        _inplace_sed "s/__CPU__/$(esc "${var.vm_cpu_count}")/g" "$OVF"
+        _inplace_sed "s/__MEM__/$(esc "${var.vm_mem_size}")/g" "$OVF"
+        _inplace_sed "s/__OS_NAME__/$(esc "$OS_NAME")/g" "$OVF"
+        _inplace_sed "s/__OS_VER__/$(esc "$OS_VER")/g" "$OVF"
+        _inplace_sed "s/__OS_DESC__/$(esc "$OS_DESC")/g" "$OVF"
+        _inplace_sed "s/__GUEST_ID__/$(esc "$GUEST_ID")/g" "$OVF"
+
+        # Manifest
+        if command -v shasum >/dev/null 2>&1; then
+          (cd "$D" && shasum -a 256 "$B.ovf" "$B.vmdk" | awk '{print "SHA256(" $2 ")= " $1 }' > "$MF")
+        else
+          (cd "$D" && sha256sum "$B.ovf" "$B.vmdk" | awk '{print "SHA256(" $2 ")= " $1 }' > "$MF")
+        fi
+
+        # pack to OVA
+        if [ "${var.pack_ova}" = "true" ]; then
+          (cd "$D" && tar -cvf "$B.ova" "$B.ovf" "$B.vmdk" "$B.mf")
+        fi
+      fi
+    EOT
+    ]
+  }
+
+  // Publish just the converted files (+ qcow2)
+  post-processor "artifice" {
+    files = [
+      "${local.output_dir}/${local.qcow2_artifact}", # .qcow2 or .qcow2.gz
+      "${local.output_dir}/${local.vm_name}.vmdk",
+      "${local.output_dir}/${local.vm_name}.vhd",
+      # we may want OVA for GCP to be part of the artifact set too, uncomment the next line:
+      # "${local.output_dir}/${local.vm_name}.ova",
+    ]
+  }
+
+  post-processor "checksum" {
+    checksum_types = ["sha256"]
+    output         = "${local.output_dir}/${local.vm_name}_CHECKSUMS"
+  }
+
+  dynamic "hcp_packer_registry" {
+    for_each = var.common_hcp_packer_registry_enabled ? [1] : []
+    content {
+      bucket_name = local.bucket_name
+      description = local.bucket_description
+      bucket_labels = {
+        "os_family"  = var.vm_guest_os_family,
+        "os_name"    = var.vm_guest_os_name,
+        "os_version" = var.vm_guest_os_version,
+      }
+      build_labels = {
+        "build_version"  = local.build_version,
+        "packer_version" = packer.version,
+      }
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -387,7 +387,7 @@
     },
     "python@latest": {
       "last_modified": "2026-04-16T08:46:55Z",
-      "plugin_version": "0.0.4",
+      "plugin_version": "0.0.5",
       "resolved": "github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b#python314",
       "source": "devbox-search",
       "version": "3.14.3",

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ set shell := ["bash", "-c"]
 
 jammy_tpl := "builds/linux/ubuntu/jammy-cloudimg.pkr.hcl"
 noble_tpl := "builds/linux/ubuntu/noble-cloudimg.pkr.hcl"
+resolute_tpl := "builds/linux/ubuntu/resolute-cloudimg.pkr.hcl"
 ubuntu_qemu_desktop_tpl := "builds/linux/ubuntu/linux-ubuntu-qemu-desktop-cloudimg.pkr.hcl"
 ubuntu_aws_tpl := "builds/linux/ubuntu/linux-ubuntu-aws.pkr.hcl"
 ubuntu_gcp_tpl := "builds/linux/ubuntu/linux-ubuntu-gcp.pkr.hcl"
@@ -21,6 +22,8 @@ init-jammy:
     packer init {{ jammy_tpl }}
 init-noble:
     packer init {{ noble_tpl }}
+init-resolute:
+    packer init {{ resolute_tpl }}
 
 init-ubuntu-qemu-desktop:
     packer init {{ ubuntu_qemu_desktop_tpl }}
@@ -37,7 +40,7 @@ init-rocky-qemu:
 init-rocky-aws:
     packer init {{ rocky_aws_tpl }}
 
-init-all: init-jammy init-noble init-ubuntu-qemu-desktop init-ubuntu-aws init-ubuntu-gcp init-rocky-qemu init-rocky-aws
+init-all: init-jammy init-noble init-resolute init-ubuntu-qemu-desktop init-ubuntu-aws init-ubuntu-gcp init-rocky-qemu init-rocky-aws
     @echo "PACKER: All templates initialized."
 init-freebsd-gcp:
     packer init {{ freebsd_gcp_tpl }}
@@ -117,6 +120,12 @@ build-noble export_ovf='true' debug='false' VARS='':
     [[ "{{ debug }}" == "true" ]] \
       && env PACKER_LOG=1 packer build -debug -force -var "export_ovf={{ export_ovf }}" {{ VARS }} {{ noble_tpl }} \
       || env PACKER_LOG=1 packer build -force        -var "export_ovf={{ export_ovf }}" {{ VARS }} {{ noble_tpl }}
+
+build-resolute export_ovf='true' debug='false' VARS='':
+    @echo "PACKER: Building Ubuntu QEMU (export_ovf={{ export_ovf }}, debug={{ debug }})"
+    [[ "{{ debug }}" == "true" ]] \
+      && env PACKER_LOG=1 packer build -debug -force -var "export_ovf={{ export_ovf }}" {{ VARS }} {{ resolute_tpl }} \
+      || env PACKER_LOG=1 packer build -force        -var "export_ovf={{ export_ovf }}" {{ VARS }} {{ resolute_tpl }}
 
 build-ubuntu-qemu-desktop iso_checksum export_ovf='false' debug='false' VARS='':
     just validate-ubuntu-qemu-desktop {{ iso_checksum }}


### PR DESCRIPTION
Ubuntu images previously pointed apt exclusively at the Princeton mirror for the archive, updates, and backports pockets. Any mirror outage broke image builds outright and left already-built hosts
with no usable package source.

The mirror is now probed before it is trusted. When it answers, it is configured and preferred as before. When it does not, the build falls back to the upstream Ubuntu archive and reports that it did so.
The upstream archive also stays configured alongside the mirror, so hosts keep working if the mirror disappears later. A repeated apt failure during the run drops the mirror and completes from upstream
instead.

closes #68 