### PR TITLE
feat: build noble container images

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -1,0 +1,159 @@
+name: Container images
+
+# Builds the systemd + Ansible container images on native runners and
+# publishes multi-arch manifests to GHCR. Native runners are used
+# deliberately: cross building these images under emulation is slow and
+# unreliable.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/ubuntu/Dockerfile
+      - docker/rocky/Dockerfile
+      - .github/workflows/container-images.yml
+  pull_request:
+    paths:
+      - docker/ubuntu/Dockerfile
+      - docker/rocky/Dockerfile
+      - .github/workflows/container-images.yml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Additional tag to publish alongside latest
+        required: false
+        default: dev
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    name: build ${{ matrix.image }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, rocky-9]
+        arch: [amd64, arm64]
+        include:
+          - image: ubuntu-22.04
+            dockerfile: docker/ubuntu/Dockerfile
+            build-args: UBUNTU_VERSION=22.04
+          - image: ubuntu-24.04
+            dockerfile: docker/ubuntu/Dockerfile
+            build-args: UBUNTU_VERSION=24.04
+          - image: ubuntu-26.04
+            dockerfile: docker/ubuntu/Dockerfile
+            build-args: UBUNTU_VERSION=26.04
+          - image: rocky-9
+            dockerfile: docker/rocky/Dockerfile
+            build-args: ""
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push per-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.arch }}
+          build-args: ${{ matrix.build-args }}
+          push: ${{ github.event_name != 'pull_request' }}
+          provenance: false
+          tags: ${{ env.NAMESPACE }}/${{ matrix.image }}:${{ matrix.arch }}-${{ github.sha }}
+
+      - name: Smoke test the image
+        if: matrix.arch == 'amd64'
+        run: |
+          set -euo pipefail
+          ref="${NAMESPACE}/${{ matrix.image }}:${{ matrix.arch }}-${GITHUB_SHA}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Image was not pushed on a pull request; skipping smoke test."
+            exit 0
+          fi
+
+          # Guards against the regressions this image has actually hit:
+          # a wiped /tmp, and a pip that rejects --break-system-packages.
+          # These are managed nodes, so a Python interpreter is all a
+          # controller needs; Ansible itself must not be installed here.
+          docker run --rm --entrypoint /bin/sh "$ref" -c '
+            set -e
+            mkdir -p /tmp/probe && echo x > /tmp/probe/AnsiballZ_setup.py
+            systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev >/dev/null 2>&1 || true
+            test -f /tmp/probe/AnsiballZ_setup.py || {
+              echo "FAIL: /tmp contents were removed by systemd-tmpfiles"; exit 1; }
+            command -v python3 | grep -qx /usr/bin/python3 || {
+              echo "FAIL: python3 does not resolve to the system interpreter"; exit 1; }
+            python3 -c "import sys; print(sys.version)" >/dev/null || {
+              echo "FAIL: python3 is not usable"; exit 1; }
+            if command -v ansible >/dev/null 2>&1; then
+              echo "FAIL: ansible is installed; these images are managed nodes"; exit 1
+            fi
+            if command -v apt-get >/dev/null; then
+              python3 -c "import apt" || { echo "FAIL: python3-apt missing"; exit 1; }
+              pip3 install --break-system-packages --dry-run wheel >/dev/null 2>&1 || {
+                echo "FAIL: pip3 rejects --break-system-packages"; exit 1; }
+            fi
+            echo "smoke test passed"
+          '
+
+  manifest:
+    name: publish ${{ matrix.image }} manifest
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, rocky-9]
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          repo="${NAMESPACE}/${{ matrix.image }}"
+
+          # `latest` is what downstream consumers pull when they omit a tag.
+          tags=(latest "${GITHUB_SHA}")
+          if [ -n "${INPUT_TAG:-}" ]; then
+            tags+=("${INPUT_TAG}")
+          fi
+
+          for tag in "${tags[@]}"; do
+            docker buildx imagetools create \
+              --tag "${repo}:${tag}" \
+              "${repo}:amd64-${GITHUB_SHA}" \
+              "${repo}:arm64-${GITHUB_SHA}"
+          done
+
+          docker buildx imagetools inspect "${repo}:latest"

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Or, using just:
 just ghcr-login
 ```
 
-(Uses `GHCR_PAT` / `GITHUB_TOKEN` / `GH_TOKEN` under the hood.)
+(Uses `GHCR_PAT` / `GITHUB_TOKEN` / `GH_TOKEN` under the hood. If no token is
+set but you are already logged in to `ghcr.io`, the existing login is reused.)
 
 ### 3. Building and Pushing Images (Local)
 
@@ -287,6 +288,16 @@ just push-resolute-docker         # pushes ghcr.io/pulibrary/vm-builds/ubuntu-26
 # Rocky 9 systemd + Ansible image
 just build-rocky-docker           # builds ghcr.io/pulibrary/vm-builds/rocky-9:dev
 just push-rocky-docker            # pushes ghcr.io/pulibrary/vm-builds/rocky-9:dev
+
+# Push all Ubuntu releases at once
+just push-ubuntu-docker-all
+```
+
+Each Ubuntu `push-*` recipe builds and links the image if needed, then
+publishes both `:<tag>` and `:latest`, so an untagged pull resolves:
+
+```bash
+docker pull ghcr.io/pulibrary/vm-builds/ubuntu-24.04
 ```
 
 All Ubuntu releases share `docker/ubuntu/Dockerfile`; the release is chosen

--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ example Prancible's Molecule suite), so a few things are guaranteed:
   `/opt/ansible` virtualenv that is deliberately kept off `PATH`.
 - `/root/.ansible/tmp` (Ansible's default `remote_tmp`) and `/var/tmp/ansible`
   are pre-created and are ordinary directories, never mount points.
+- **`pip3` accepts `--break-system-packages` on every release.** Ubuntu 22.04
+  ships a pip too old to know that flag, while 24.04 and later require it to
+  install into the system environment, so the same `ansible.builtin.pip` task
+  would fail on 22.04 only. The 22.04 image upgrades its system pip to close
+  that gap; newer releases keep their distro-managed pip.
 
 ### Architecture matters
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,16 @@ just build-ubuntu-gcp pul-gcdc zone=us-east1-b machine_type=e2-standard-2
 ### Docker Images
 
 ```bash
-# Ubuntu 22.04 systemd + Ansible image
-just build-ubuntu-docker          # builds ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
-just push-ubuntu-docker           # pushes ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+# Ubuntu 22.04 (jammy) systemd + Ansible image
+just build-jammy-docker           # builds ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+just push-jammy-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+
+# Ubuntu 24.04 (noble) systemd + Ansible image
+just build-noble-docker           # builds ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
+just push-noble-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
+
+# Both Ubuntu releases in one go
+just build-ubuntu-docker-all
 
 # Rocky 9 systemd + Ansible image
 just build-rocky-docker           # builds ghcr.io/pulibrary/vm-builds/rocky-9:dev
@@ -197,14 +204,15 @@ packer build -var "gcp_project_id=pul-gcdc" \
 
 In addition to VM images, this repo builds **systemd-capable** Docker images that double as Ansible control hosts. Images are published to **GitHub Container Registry (GHCR)** under:
 
-- `ghcr.io/pulibrary/vm-builds/ubuntu-22.04:<tag>`
+- `ghcr.io/pulibrary/vm-builds/ubuntu-22.04:<tag>` (jammy)
+- `ghcr.io/pulibrary/vm-builds/ubuntu-24.04:<tag>` (noble)
 - `ghcr.io/pulibrary/vm-builds/rocky-9:<tag>`
 
 These images:
 
 - Run `systemd` as PID 1 (for testing services with units)
 - Include `pulsys` with passwordless sudo
-- Have Python + Ansible core installed, plus the collections in `ansible/collections.yaml`
+- Have Python + Ansible core installed in a `/opt/ansible` virtualenv, plus the collections in `ansible/collections.yaml`
 
 ### 1. Creating a Token for GHCR
 
@@ -220,7 +228,7 @@ Steps:
    **Settings → Developer settings → Personal access tokens → Tokens (classic)**.
 2. Click **"Generate new token (classic)"**.
 3. Give it a descriptive name, e.g. `vm-builds-ghcr`.
-4. Set an **expiration** that matches your org policy.
+4. Set an **expiration**.
 5. Under **Scopes**, select at least:
    - `read:packages`
    - `write:packages`
@@ -259,25 +267,42 @@ just ghcr-login
 From the repo root:
 
 ```bash
-# Ubuntu 22.04 systemd + Ansible image
-just build-ubuntu-docker          # builds ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
-just push-ubuntu-docker           # pushes ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+# Ubuntu 22.04 (jammy) systemd + Ansible image
+just build-jammy-docker           # builds ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+just push-jammy-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+
+# Ubuntu 24.04 (noble) systemd + Ansible image
+just build-noble-docker           # builds ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
+just push-noble-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
 
 # Rocky 9 systemd + Ansible image
 just build-rocky-docker           # builds ghcr.io/pulibrary/vm-builds/rocky-9:dev
 just push-rocky-docker            # pushes ghcr.io/pulibrary/vm-builds/rocky-9:dev
 ```
 
+Both Ubuntu releases share `docker/ubuntu/Dockerfile`; the release is chosen
+with the `UBUNTU_VERSION` build argument, so any future release can be built
+without editing the Dockerfile:
+
+```bash
+just build-ubuntu-docker dev 24.04
+just push-ubuntu-docker  dev 24.04
+```
+
 You can override the tag (e.g., use a date or git SHA):
 
 ```bash
-just build-ubuntu-docker 2025-11-13
-just push-ubuntu-docker  2025-11-13
+just build-jammy-docker 2025-11-13
+just push-jammy-docker  2025-11-13
+
+just build-noble-docker 2025-11-13
+just push-noble-docker  2025-11-13
 ```
 
 Resulting tags:
 
 - `ghcr.io/pulibrary/vm-builds/ubuntu-22.04:2025-11-13`
+- `ghcr.io/pulibrary/vm-builds/ubuntu-24.04:2025-11-13`
 - `ghcr.io/pulibrary/vm-builds/rocky-9:2025-11-13`
 
 ### 4. Pulling and Running the Images
@@ -286,6 +311,7 @@ Pull:
 
 ```bash
 docker pull ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
+docker pull ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
 docker pull ghcr.io/pulibrary/vm-builds/rocky-9:dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,65 @@ publishes both `:<tag>` and `:latest`, so an untagged pull resolves:
 docker pull ghcr.io/pulibrary/vm-builds/ubuntu-24.04
 ```
 
+### Using these images as Ansible targets
+
+These images are built to be driven by an external Ansible controller (for
+example Prancible's Molecule suite), so a few things are guaranteed:
+
+- **`apt`/`dnf` metadata is kept in the image.** Package tasks work without
+  `update_cache: true`; dropping the lists makes tasks fail with
+  `No package matching '<name>' is available`.
+- **Nothing sweeps `/tmp`.** The distro ships a systemd-tmpfiles rule that
+  empties `/tmp` during boot. A controller connecting while the container is
+  still booting could have its staged module deleted mid-task, failing with
+  `can't open file .../AnsiballZ_setup.py: No such file or directory`. These
+  images override that rule so `/tmp` contents are never removed.
+- **No `VOLUME` declarations.** `/run`, `/tmp` and `/sys/fs/cgroup` are left to
+  the caller to mount. Declaring them as volumes creates anonymous volumes that
+  shadow the caller's mounts and makes copying files into those paths behave
+  differently under Docker and Podman.
+- **`python3` resolves to the system interpreter**, so modules that need
+  system packages such as `python3-apt` work. Ansible itself lives in a
+  `/opt/ansible` virtualenv that is deliberately kept off `PATH`.
+- `/root/.ansible/tmp` (Ansible's default `remote_tmp`) and `/var/tmp/ansible`
+  are pre-created and are ordinary directories, never mount points.
+
+### Architecture matters
+
+Downstream consumers (Prancible's molecule suite on GitHub Actions) run on
+**amd64**, while developer laptops are usually **arm64**. A container image
+only runs on the architecture it was built for; publishing an arm64-only image
+makes every command inside it fail with `Exec format error`, which surfaces
+downstream as misleading Ansible errors such as "Failed to create temporary
+directory".
+
+Because of this, **all Ubuntu and Rocky build recipes produce a multi-arch
+(amd64 + arm64) manifest by default**, and the `push-*` recipes refuse to
+publish anything that does not include amd64.
+
+```bash
+# multi-arch (default)
+just build-jammy-docker
+just build-rocky-docker
+
+# host architecture only: fast local iteration, never publish this
+just build-jammy-docker-native
+just build-rocky-docker-native
+```
+
+Multi-arch builds need working cross-architecture emulation. The recipes
+check this up front and fail in seconds rather than minutes:
+
+```bash
+just check-emulation
+# install emulation if it is missing:
+docker run --privileged --rm docker.io/tonistiigi/binfmt --install all
+```
+
+If emulation is unavailable, let CI publish instead: the **container-images**
+GitHub Actions workflow builds every Ubuntu release and Rocky 9 on a native
+amd64 and arm64 runner, so no emulation is involved.
+
 All Ubuntu releases share `docker/ubuntu/Dockerfile`; the release is chosen
 with the `UBUNTU_VERSION` build argument, so any future release can be built
 without editing the Dockerfile:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ packer build -var "gcp_project_id=pul-gcdc" \
 
 ## Docker Images (systemd-capable, on GHCR)
 
-In addition to VM images, this repo builds **systemd-capable** Docker images that double as Ansible control hosts. Images are published to **GitHub Container Registry (GHCR)** under:
+In addition to VM images, this repo builds **systemd-capable** Docker images used as **Ansible managed nodes** (test targets). Images are published to **GitHub Container Registry (GHCR)** under:
 
 - `ghcr.io/pulibrary/vm-builds/ubuntu-22.04:<tag>` (jammy)
 - `ghcr.io/pulibrary/vm-builds/ubuntu-24.04:<tag>` (noble)
@@ -217,7 +217,12 @@ These images:
 
 - Run `systemd` as PID 1 (for testing services with units)
 - Include `pulsys` with passwordless sudo
-- Have Python + Ansible core installed in a `/opt/ansible` virtualenv, plus the collections in `ansible/collections.yaml`
+- Provide a system Python interpreter, which is all an Ansible target needs
+
+Ansible itself is **not** installed. These are managed nodes, not control
+hosts: the controller ships its own module code over the connection, so
+installing Ansible in the target would only add weight and a second
+version to keep in sync.
 
 ### 1. Creating a Token for GHCR
 
@@ -318,8 +323,7 @@ example Prancible's Molecule suite), so a few things are guaranteed:
   shadow the caller's mounts and makes copying files into those paths behave
   differently under Docker and Podman.
 - **`python3` resolves to the system interpreter**, so modules that need
-  system packages such as `python3-apt` work. Ansible itself lives in a
-  `/opt/ansible` virtualenv that is deliberately kept off `PATH`.
+  system packages such as `python3-apt` work.
 - `/root/.ansible/tmp` (Ansible's default `remote_tmp`) and `/var/tmp/ansible`
   are pre-created and are ordinary directories, never mount points.
 - **`pip3` accepts `--break-system-packages` on every release.** Ubuntu 22.04
@@ -362,7 +366,13 @@ docker run --privileged --rm docker.io/tonistiigi/binfmt --install all
 
 If emulation is unavailable, let CI publish instead: the **container-images**
 GitHub Actions workflow builds every Ubuntu release and Rocky 9 on a native
-amd64 and arm64 runner, so no emulation is involved.
+amd64 and arm64 runner, so no emulation is involved. It also smoke tests each
+image before publishing and refuses to promote one that regresses on the
+things that have broken downstream tests before (a wiped `/tmp`, an interpreter
+that does not resolve to the system Python, or a `pip3` that rejects
+`--break-system-packages`), and on Ansible reappearing in a managed node. It
+runs on pushes to `main` that touch the Dockerfiles, and can be triggered
+manually.
 
 All Ubuntu releases share `docker/ubuntu/Dockerfile`; the release is chosen
 with the `UBUNTU_VERSION` build argument, so any future release can be built
@@ -449,7 +459,7 @@ Inside the container you can then:
 ```bash
 docker exec -it ubuntu-systemd bash
 systemctl status
-ansible-galaxy collection list
+python3 --version
 ```
 
 ## Ansible Roles

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ just push-jammy-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-22
 just build-noble-docker           # builds ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
 just push-noble-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
 
-# Both Ubuntu releases in one go
+# Ubuntu 26.04 (resolute) systemd + Ansible image
+just build-resolute-docker        # builds ghcr.io/pulibrary/vm-builds/ubuntu-26.04:dev
+just push-resolute-docker         # pushes ghcr.io/pulibrary/vm-builds/ubuntu-26.04:dev
+
+# All Ubuntu releases in one go
 just build-ubuntu-docker-all
 
 # Rocky 9 systemd + Ansible image
@@ -206,6 +210,7 @@ In addition to VM images, this repo builds **systemd-capable** Docker images tha
 
 - `ghcr.io/pulibrary/vm-builds/ubuntu-22.04:<tag>` (jammy)
 - `ghcr.io/pulibrary/vm-builds/ubuntu-24.04:<tag>` (noble)
+- `ghcr.io/pulibrary/vm-builds/ubuntu-26.04:<tag>` (resolute)
 - `ghcr.io/pulibrary/vm-builds/rocky-9:<tag>`
 
 These images:
@@ -275,18 +280,22 @@ just push-jammy-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-22
 just build-noble-docker           # builds ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
 just push-noble-docker            # pushes ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
 
+# Ubuntu 26.04 (resolute) systemd + Ansible image
+just build-resolute-docker        # builds ghcr.io/pulibrary/vm-builds/ubuntu-26.04:dev
+just push-resolute-docker         # pushes ghcr.io/pulibrary/vm-builds/ubuntu-26.04:dev
+
 # Rocky 9 systemd + Ansible image
 just build-rocky-docker           # builds ghcr.io/pulibrary/vm-builds/rocky-9:dev
 just push-rocky-docker            # pushes ghcr.io/pulibrary/vm-builds/rocky-9:dev
 ```
 
-Both Ubuntu releases share `docker/ubuntu/Dockerfile`; the release is chosen
+All Ubuntu releases share `docker/ubuntu/Dockerfile`; the release is chosen
 with the `UBUNTU_VERSION` build argument, so any future release can be built
 without editing the Dockerfile:
 
 ```bash
-just build-ubuntu-docker dev 24.04
-just push-ubuntu-docker  dev 24.04
+just build-ubuntu-docker dev 26.04
+just push-ubuntu-docker  dev 26.04
 ```
 
 You can override the tag (e.g., use a date or git SHA):
@@ -297,16 +306,21 @@ just push-jammy-docker  2025-11-13
 
 just build-noble-docker 2025-11-13
 just push-noble-docker  2025-11-13
+
+just build-resolute-docker 2025-11-13
+just push-resolute-docker  2025-11-13
 ```
 
 Resulting tags:
 
 - `ghcr.io/pulibrary/vm-builds/ubuntu-22.04:2025-11-13`
 - `ghcr.io/pulibrary/vm-builds/ubuntu-24.04:2025-11-13`
+- `ghcr.io/pulibrary/vm-builds/ubuntu-26.04:2025-11-13`
 - `ghcr.io/pulibrary/vm-builds/rocky-9:2025-11-13`
 
 To alias a built image so the short local name, the fully qualified GHCR
-name, and the GHCR `:latest` tag all point at the same image:
+name, and the GHCR `:latest` tag all point at the same image (the image is
+built first if it is not present locally):
 
 ```bash
 # ubuntu-22.04:dev <-> ghcr.io/pulibrary/vm-builds/ubuntu-22.04
@@ -315,7 +329,10 @@ just link-jammy-docker
 # ubuntu-24.04:dev <-> ghcr.io/pulibrary/vm-builds/ubuntu-24.04
 just link-noble-docker
 
-# both releases at once
+# ubuntu-26.04:dev <-> ghcr.io/pulibrary/vm-builds/ubuntu-26.04
+just link-resolute-docker
+
+# all releases at once
 just link-ubuntu-docker-all
 ```
 
@@ -326,6 +343,7 @@ Pull:
 ```bash
 docker pull ghcr.io/pulibrary/vm-builds/ubuntu-22.04:dev
 docker pull ghcr.io/pulibrary/vm-builds/ubuntu-24.04:dev
+docker pull ghcr.io/pulibrary/vm-builds/ubuntu-26.04:dev
 docker pull ghcr.io/pulibrary/vm-builds/rocky-9:dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,20 @@ Resulting tags:
 - `ghcr.io/pulibrary/vm-builds/ubuntu-24.04:2025-11-13`
 - `ghcr.io/pulibrary/vm-builds/rocky-9:2025-11-13`
 
+To alias a built image so the short local name, the fully qualified GHCR
+name, and the GHCR `:latest` tag all point at the same image:
+
+```bash
+# ubuntu-22.04:dev <-> ghcr.io/pulibrary/vm-builds/ubuntu-22.04
+just link-jammy-docker
+
+# ubuntu-24.04:dev <-> ghcr.io/pulibrary/vm-builds/ubuntu-24.04
+just link-noble-docker
+
+# both releases at once
+just link-ubuntu-docker-all
+```
+
 ### 4. Pulling and Running the Images
 
 Pull:

--- a/docker/rocky/Dockerfile
+++ b/docker/rocky/Dockerfile
@@ -4,6 +4,9 @@ FROM rockylinux:9
 ENV TZ=UTC \
     container=docker
 
+# Ansible is deliberately NOT installed: this image is a managed node, not a
+# control host. The controller ships its own module code over the connection,
+# so all a target needs is a Python interpreter.
 RUN dnf -y update \
     && dnf -y install \
        systemd \
@@ -22,20 +25,7 @@ RUN useradd -m -s /bin/bash pulsys && \
 
 RUN mkdir -p /run/systemd /var/log/journal /var/run/sshd
 
-# ansible-core 2.15.x works with Python 3.9
-RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install \
-         ansible-core==2.15.13 \
-         pyopenssl
-
-COPY ansible/collections.yaml /tmp/collections.yaml
-RUN ansible-galaxy collection install -r /tmp/collections.yaml \
-    && rm -f /tmp/collections.yaml
-
-RUN mkdir -p /etc/ansible \
-    && printf "[local]\nlocalhost ansible_connection=local\n" > /etc/ansible/hosts
-
-# Somewhere for an Ansible controller to stage modules. Both paths are plain
+# Somewhere for a controller to stage modules. Both paths are plain
 # directories in the image, never mount points, so a controller can write here
 # and then execute what it wrote. Putting Ansible's remote_tmp on a tmpfs or
 # volume mount instead is unreliable and shows up as

--- a/docker/rocky/Dockerfile
+++ b/docker/rocky/Dockerfile
@@ -35,11 +35,19 @@ RUN ansible-galaxy collection install -r /tmp/collections.yaml \
 RUN mkdir -p /etc/ansible \
     && printf "[local]\nlocalhost ansible_connection=local\n" > /etc/ansible/hosts
 
-RUN mkdir -p /root/.ansible/tmp /tmp/ansible \
-    && chmod -R 777 /root/.ansible/tmp \
-    && chmod -R 1777 /tmp/ansible
+# Somewhere for an Ansible controller to stage modules. Both paths are plain
+# directories in the image, never mount points, so a controller can write here
+# and then execute what it wrote. Putting Ansible's remote_tmp on a tmpfs or
+# volume mount instead is unreliable and shows up as
+# "can't open file .../AnsiballZ_setup.py: No such file or directory".
+RUN mkdir -p /root/.ansible/tmp /var/tmp/ansible \
+    && chmod 700 /root/.ansible/tmp \
+    && chmod 1777 /var/tmp/ansible
 
-# Optimize systemd for container use
+# Optimize systemd for container use.
+# tmp.mount and systemd-tmpfiles-clean are masked so systemd can never remount
+# or sweep /tmp while a playbook is running against this container; that would
+# silently delete files a controller has already written there.
 RUN systemctl mask \
     systemd-remount-fs.service \
     sys-kernel-config.mount \
@@ -50,10 +58,25 @@ RUN systemctl mask \
     systemd-update-utmp.service \
     systemd-tmpfiles-setup-dev.service \
     dnf-makecache.timer \
-    kdump.service
+    kdump.service \
+    tmp.mount \
+    systemd-tmpfiles-clean.timer \
+    systemd-tmpfiles-clean.service
 
 # Disable network wait service
 RUN systemctl disable NetworkManager-wait-online.service 2>/dev/null || true
+
+# Stop systemd from emptying /tmp and /var/tmp while a playbook is running.
+# The shipped /usr/lib/tmpfiles.d/tmp.conf tells
+# systemd-tmpfiles-setup.service (running --create --remove --boot) to delete
+# everything under /tmp during boot. A controller that connects while the
+# container is still booting can have its staged files deleted mid-task, which
+# fails as "can't open file .../AnsiballZ_setup.py: No such file or directory".
+# A file of the same name in /etc/tmpfiles.d overrides the shipped one, and
+# lowercase "d" creates the directory without ever removing its contents.
+RUN mkdir -p /etc/tmpfiles.d \
+    && printf 'd /tmp 1777 root root -\nd /var/tmp 1777 root root -\n' \
+       > /etc/tmpfiles.d/tmp.conf
 
 # Configure journald for minimal overhead
 RUN mkdir -p /etc/systemd/journald.conf.d && \
@@ -61,5 +84,8 @@ RUN mkdir -p /etc/systemd/journald.conf.d && \
 
 EXPOSE 22
 STOPSIGNAL SIGRTMIN+3
-VOLUME ["/sys/fs/cgroup", "/run", "/tmp"]
+# No VOLUME here on purpose. Declaring /run, /tmp or /sys/fs/cgroup as volumes
+# creates anonymous volumes that shadow whatever the caller mounts and makes
+# copying files into those paths behave inconsistently between Docker and
+# Podman. Callers mount what they need (see README).
 CMD ["/sbin/init"]

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,9 +1,14 @@
 # docker/ubuntu/Dockerfile
 # syntax = docker/dockerfile:1.4
-FROM ubuntu:22.04
+ARG UBUNTU_VERSION=22.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG ANSIBLE_CORE_VERSION=2.16.3
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
-    container=docker
+    container=docker \
+    ANSIBLE_VENV=/opt/ansible \
+    PATH=/opt/ansible/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Base OS + systemd + useful tools
 RUN apt-get update \
@@ -27,27 +32,32 @@ RUN useradd -m -s /bin/bash pulsys && \
 RUN mkdir -p /run/systemd /var/log/journal /var/run/sshd
 
 # Optimize systemd for container use
-RUN systemctl mask \
-    systemd-remount-fs.service \
-    sys-kernel-config.mount \
-    sys-kernel-debug.mount \
-    sys-kernel-tracing.mount \
-    e2scrub_reap.service \
-    systemd-pstore.service \
-    systemd-ask-password-wall.path \
-    systemd-update-utmp.service
+RUN for unit in \
+      systemd-remount-fs.service \
+      sys-kernel-config.mount \
+      sys-kernel-debug.mount \
+      sys-kernel-tracing.mount \
+      e2scrub_reap.service \
+      systemd-pstore.service \
+      systemd-ask-password-wall.path \
+      systemd-update-utmp.service; do \
+      systemctl mask "$unit" || echo "skip mask $unit"; \
+    done
 
 # Disable network wait service (major culprit for delays)
-RUN systemctl disable systemd-networkd-wait-online.service
+RUN systemctl disable systemd-networkd-wait-online.service \
+    || echo "skip disable systemd-networkd-wait-online.service"
 
 # Configure journald for minimal overhead
 RUN mkdir -p /etc/systemd/journald.conf.d && \
-    echo -e "[Journal]\nStorage=volatile\nRuntimeMaxUse=8M" > /etc/systemd/journald.conf.d/volatile.conf
+    printf '[Journal]\nStorage=volatile\nRuntimeMaxUse=8M\n' > /etc/systemd/journald.conf.d/volatile.conf
 
-# Ansible bits
-RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install \
-         ansible-core==2.16.3 \
+# Ansible bits, isolated in a venv so newer Ubuntu releases
+# with externally managed system Python (PEP 668) build cleanly
+RUN python3 -m venv "$ANSIBLE_VENV" \
+    && "$ANSIBLE_VENV/bin/python" -m pip install --upgrade pip setuptools wheel \
+    && "$ANSIBLE_VENV/bin/python" -m pip install \
+         "ansible-core==${ANSIBLE_CORE_VERSION}" \
          pyopenssl
 
 COPY ansible/collections.yaml /tmp/collections.yaml

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -27,6 +27,16 @@ RUN apt-get update \
        python3-venv \
        python3-pip
 
+# Make the system pip behave the same on every release. Ubuntu 22.04 ships
+# pip 22.0.2, which predates `--break-system-packages` (added in pip 23.0),
+# while 24.04 and later ship a pip that requires that flag to touch the system
+# environment. Without this, a playbook that works against newer releases fails
+RUN pip_major=$(/usr/bin/pip3 --version | awk '{print $2}' | cut -d. -f1) \
+    && if [ "$pip_major" -lt 23 ]; then \
+         /usr/bin/pip3 install --no-cache-dir --upgrade 'pip>=23.1'; \
+       fi \
+    && /usr/bin/pip3 --version
+
 # pulsys admin user
 RUN useradd -m -s /bin/bash pulsys && \
     echo "pulsys ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-pulsys && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -3,17 +3,17 @@
 ARG UBUNTU_VERSION=22.04
 FROM ubuntu:${UBUNTU_VERSION}
 
-ARG ANSIBLE_CORE_VERSION=2.16.3
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
-    container=docker \
-    ANSIBLE_VENV=/opt/ansible
+    container=docker
 
 # Base OS + systemd + useful tools.
-# The apt lists are deliberately kept: this image is used as an Ansible target
-# in tests, and dropping them makes plain `apt` tasks fail with
-# "No package matching '<name>' is available" unless every task remembers
-# update_cache: true.
+# Ansible is deliberately NOT installed: this image is a managed node, not a
+# control host. The controller ships its own module code over the connection,
+# so all a target needs is a Python interpreter.
+# The apt lists are deliberately kept: dropping them makes plain `apt` tasks
+# fail with "No package matching '<name>' is available" unless every task
+# remembers update_cache: true.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        systemd systemd-sysv \
@@ -31,6 +31,8 @@ RUN apt-get update \
 # pip 22.0.2, which predates `--break-system-packages` (added in pip 23.0),
 # while 24.04 and later ship a pip that requires that flag to touch the system
 # environment. Without this, a playbook that works against newer releases fails
+# on 22.04 with "no such option: --break-system-packages". Only older pips are
+# upgraded, so newer releases keep their distro-managed pip.
 RUN pip_major=$(/usr/bin/pip3 --version | awk '{print $2}' | cut -d. -f1) \
     && if [ "$pip_major" -lt 23 ]; then \
          /usr/bin/pip3 install --no-cache-dir --upgrade 'pip>=23.1'; \
@@ -84,29 +86,7 @@ RUN mkdir -p /etc/tmpfiles.d \
 RUN mkdir -p /etc/systemd/journald.conf.d && \
     printf '[Journal]\nStorage=volatile\nRuntimeMaxUse=8M\n' > /etc/systemd/journald.conf.d/volatile.conf
 
-# Ansible bits, isolated in a venv so newer Ubuntu releases
-# with externally managed system Python (PEP 668) build cleanly.
-# The venv is deliberately kept off PATH: Ansible discovers a target's
-# interpreter with `command -v python3`, and a venv python cannot see
-# system packages such as python3-apt. Only the ansible entry points are
-# exposed, so this image still works as an Ansible control host.
-RUN python3 -m venv "$ANSIBLE_VENV" \
-    && "$ANSIBLE_VENV/bin/python" -m pip install --upgrade pip setuptools wheel \
-    && "$ANSIBLE_VENV/bin/python" -m pip install \
-         "ansible-core==${ANSIBLE_CORE_VERSION}" \
-         pyopenssl \
-    && for bin in "$ANSIBLE_VENV"/bin/ansible*; do \
-         ln -sf "$bin" "/usr/local/bin/$(basename "$bin")"; \
-       done
-
-COPY ansible/collections.yaml /tmp/collections.yaml
-RUN ansible-galaxy collection install -r /tmp/collections.yaml \
-    && rm -f /tmp/collections.yaml
-
-RUN mkdir -p /etc/ansible \
-    && printf "[local]\nlocalhost ansible_connection=local\n" > /etc/ansible/hosts
-
-# Somewhere for an Ansible controller to stage modules. Both paths are plain
+# Somewhere for a controller to stage modules. Both paths are plain
 # directories in the image, never mount points, so a controller can write here
 # and then execute what it wrote. Putting Ansible's remote_tmp on a tmpfs or
 # volume mount instead is unreliable and shows up as

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -7,10 +7,13 @@ ARG ANSIBLE_CORE_VERSION=2.16.3
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
     container=docker \
-    ANSIBLE_VENV=/opt/ansible \
-    PATH=/opt/ansible/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    ANSIBLE_VENV=/opt/ansible
 
-# Base OS + systemd + useful tools
+# Base OS + systemd + useful tools.
+# The apt lists are deliberately kept: this image is used as an Ansible target
+# in tests, and dropping them makes plain `apt` tasks fail with
+# "No package matching '<name>' is available" unless every task remembers
+# update_cache: true.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        systemd systemd-sysv \
@@ -18,10 +21,11 @@ RUN apt-get update \
        openssh-server \
        net-tools \
        ca-certificates \
+       gnupg \
        python3 \
+       python3-apt \
        python3-venv \
-       python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+       python3-pip
 
 # pulsys admin user
 RUN useradd -m -s /bin/bash pulsys && \
@@ -31,7 +35,10 @@ RUN useradd -m -s /bin/bash pulsys && \
 # Prepare systemd dirs
 RUN mkdir -p /run/systemd /var/log/journal /var/run/sshd
 
-# Optimize systemd for container use
+# Optimize systemd for container use.
+# tmp.mount and systemd-tmpfiles-clean are masked so systemd can never remount
+# or sweep /tmp while a playbook is running against this container; that would
+# silently delete files a controller has already written there.
 RUN for unit in \
       systemd-remount-fs.service \
       sys-kernel-config.mount \
@@ -40,7 +47,10 @@ RUN for unit in \
       e2scrub_reap.service \
       systemd-pstore.service \
       systemd-ask-password-wall.path \
-      systemd-update-utmp.service; do \
+      systemd-update-utmp.service \
+      tmp.mount \
+      systemd-tmpfiles-clean.timer \
+      systemd-tmpfiles-clean.service; do \
       systemctl mask "$unit" || echo "skip mask $unit"; \
     done
 
@@ -48,17 +58,36 @@ RUN for unit in \
 RUN systemctl disable systemd-networkd-wait-online.service \
     || echo "skip disable systemd-networkd-wait-online.service"
 
+# Stop systemd from emptying /tmp and /var/tmp while a playbook is running.
+# The shipped /usr/lib/tmpfiles.d/tmp.conf uses "D", which tells
+# systemd-tmpfiles-setup.service (running --create --remove --boot) to delete
+# everything under /tmp during boot. A controller that connects while the
+# container is still booting can have its staged files deleted mid-task, which
+# fails as "can't open file .../AnsiballZ_setup.py: No such file or directory".
+# A file of the same name in /etc/tmpfiles.d overrides the shipped one, and
+# lowercase "d" creates the directory without ever removing its contents.
+RUN mkdir -p /etc/tmpfiles.d \
+    && printf 'd /tmp 1777 root root -\nd /var/tmp 1777 root root -\n' \
+       > /etc/tmpfiles.d/tmp.conf
+
 # Configure journald for minimal overhead
 RUN mkdir -p /etc/systemd/journald.conf.d && \
     printf '[Journal]\nStorage=volatile\nRuntimeMaxUse=8M\n' > /etc/systemd/journald.conf.d/volatile.conf
 
 # Ansible bits, isolated in a venv so newer Ubuntu releases
-# with externally managed system Python (PEP 668) build cleanly
+# with externally managed system Python (PEP 668) build cleanly.
+# The venv is deliberately kept off PATH: Ansible discovers a target's
+# interpreter with `command -v python3`, and a venv python cannot see
+# system packages such as python3-apt. Only the ansible entry points are
+# exposed, so this image still works as an Ansible control host.
 RUN python3 -m venv "$ANSIBLE_VENV" \
     && "$ANSIBLE_VENV/bin/python" -m pip install --upgrade pip setuptools wheel \
     && "$ANSIBLE_VENV/bin/python" -m pip install \
          "ansible-core==${ANSIBLE_CORE_VERSION}" \
-         pyopenssl
+         pyopenssl \
+    && for bin in "$ANSIBLE_VENV"/bin/ansible*; do \
+         ln -sf "$bin" "/usr/local/bin/$(basename "$bin")"; \
+       done
 
 COPY ansible/collections.yaml /tmp/collections.yaml
 RUN ansible-galaxy collection install -r /tmp/collections.yaml \
@@ -67,11 +96,19 @@ RUN ansible-galaxy collection install -r /tmp/collections.yaml \
 RUN mkdir -p /etc/ansible \
     && printf "[local]\nlocalhost ansible_connection=local\n" > /etc/ansible/hosts
 
-RUN mkdir -p /root/.ansible/tmp /tmp/ansible \
-    && chmod -R 777 /root/.ansible/tmp \
-    && chmod -R 1777 /tmp/ansible
+# Somewhere for an Ansible controller to stage modules. Both paths are plain
+# directories in the image, never mount points, so a controller can write here
+# and then execute what it wrote. Putting Ansible's remote_tmp on a tmpfs or
+# volume mount instead is unreliable and shows up as
+# "can't open file .../AnsiballZ_setup.py: No such file or directory".
+RUN mkdir -p /root/.ansible/tmp /var/tmp/ansible \
+    && chmod 700 /root/.ansible/tmp \
+    && chmod 1777 /var/tmp/ansible
 
 EXPOSE 22
 STOPSIGNAL SIGRTMIN+3
-VOLUME ["/sys/fs/cgroup", "/run", "/tmp"]
+# No VOLUME here on purpose. Declaring /run, /tmp or /sys/fs/cgroup as volumes
+# creates anonymous volumes that shadow whatever the caller mounts and makes
+# copying files into those paths behave inconsistently between Docker and
+# Podman. Callers mount what they need (see README).
 CMD ["/sbin/init"]

--- a/justfile
+++ b/justfile
@@ -193,35 +193,107 @@ ghcr-login:
 # Default Ubuntu release used by the docker recipes
 UBUNTU_DOCKER_VERSION := "22.04"
 
-# Build an Ubuntu systemd-capable Ansible control image
-# Uses docker/ubuntu/Dockerfile; version selects the Ubuntu release (22.04, 24.04, ...)
-build-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
+# Architectures published for the container images. Multi-arch is the default
+# so one tag runs on CI (amd64) and on developer laptops (arm64) alike.
+DOCKER_PLATFORMS := "linux/amd64,linux/arm64"
+
+# Architecture that downstream CI (GitHub Actions, molecule) runs on.
+# Publishing an image without it makes every command in the container fail
+# with "Exec format error", which surfaces downstream as confusing Ansible
+# errors such as "Failed to create temporary directory".
+DOCKER_CI_ARCH := "amd64"
+
+# Verify cross-architecture emulation works before starting a long multi-arch
+# build, so failures are immediate and obvious rather than 10 minutes deep.
+check-emulation platforms=DOCKER_PLATFORMS:
+    @probe=docker.io/library/alpine:3; \
+     docker pull -q "$probe" >/dev/null 2>&1 || true; \
+     for platform in $(echo "{{ platforms }}" | tr ',' ' '); do \
+       if ! docker run --rm --platform "$platform" "$probe" true >/dev/null 2>&1; then \
+         echo "ERROR: this host cannot run $platform images." >&2; \
+         echo "       Multi-arch builds need working binfmt/qemu emulation." >&2; \
+         echo "       Options:" >&2; \
+         echo "         - let CI publish it: the ubuntu-docker workflow builds each" >&2; \
+         echo "           architecture on a native runner (no emulation needed)" >&2; \
+         echo "         - install emulation: docker run --privileged --rm \\" >&2; \
+         echo "             docker.io/tonistiigi/binfmt --install all" >&2; \
+         echo "         - build for this host only: just build-ubuntu-docker-native" >&2; \
+         exit 1; \
+       fi; \
+     done; \
+     echo "DOCKER: emulation OK for {{ platforms }}"
+
+# Drop any existing tag with this name so a manifest list can take it over.
+# Building a manifest fails if the name is already a plain single-arch image,
+# which is common after a native build.
+_free-image-name ref:
+    @if docker manifest exists "{{ ref }}" 2>/dev/null; then \
+       docker manifest rm "{{ ref }}" >/dev/null; \
+     elif docker image exists "{{ ref }}" 2>/dev/null; then \
+       docker untag "{{ ref }}" >/dev/null; \
+     fi
+
+# Build an Ubuntu systemd-capable Ansible control image.
+# Uses docker/ubuntu/Dockerfile; version selects the Ubuntu release.
+# Produces a multi-arch manifest by default.
+build-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION platforms=DOCKER_PLATFORMS:
+    just check-emulation {{ platforms }}
+    just _free-image-name {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}}
+    @for platform in $(echo "{{ platforms }}" | tr ',' ' '); do \
+       echo "DOCKER: building Ubuntu {{ version }} for $platform"; \
+       docker build \
+         --platform "$platform" \
+         -f docker/ubuntu/Dockerfile \
+         --build-arg UBUNTU_VERSION={{ version }} \
+         --manifest {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}} \
+         . || exit 1; \
+     done
+
+# Build for the host architecture only. Fast for local iteration; never
+# publish the result, since other architectures cannot run it.
+build-ubuntu-docker-native tag="dev" version=UBUNTU_DOCKER_VERSION:
     docker build \
       -f docker/ubuntu/Dockerfile \
       --build-arg UBUNTU_VERSION={{ version }} \
       -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}} \
       .
 
-# Multi-arch build & push for Ubuntu
-# Publishes both the given tag and :latest so `docker pull` without a tag works
+# Kept for discoverability; multi-arch is now the default
 build-ubuntu-docker-multi tag="dev" version=UBUNTU_DOCKER_VERSION:
-    just ghcr-login
-    docker buildx build \
-      --platform linux/amd64,linux/arm64/v8 \
-      -f docker/ubuntu/Dockerfile \
-      --build-arg UBUNTU_VERSION={{ version }} \
-      -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}} \
-      -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:latest \
-      --push \
-      .
+    just build-ubuntu-docker {{ tag }} {{ version }}
 
 # Push Ubuntu image to GHCR, including the :latest tag so that
-# `docker pull ghcr.io/pulibrary/vm-builds/ubuntu-<version>` resolves
-push-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
+# `docker pull ghcr.io/pulibrary/vm-builds/ubuntu-<version>` resolves.
+# Refuses to publish anything that cannot run on the CI architecture;
+# pass force=true only if you know every consumer matches your host.
+push-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION force="false":
     just link-ubuntu-docker {{ tag }} {{ version }}
+    @ref="{{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{ tag }}"; \
+     if docker manifest exists "$ref" 2>/dev/null; then \
+       archs=$(docker manifest inspect "$ref" | grep '"architecture"' | cut -d'"' -f4 | sort -u | tr '\n' ' '); \
+     else \
+       archs=$(docker image inspect "$ref" | grep -m1 '"Architecture"' | cut -d'"' -f4); \
+     fi; \
+     case " $archs " in \
+       *" {{ DOCKER_CI_ARCH }} "*) ;; \
+       *) if [ "{{ force }}" != "true" ]; then \
+            echo "ERROR: $ref covers [$archs] but downstream CI needs {{ DOCKER_CI_ARCH }}." >&2; \
+            echo "       Publishing it would break molecule with 'Exec format error'." >&2; \
+            echo "       Rebuild multi-arch: just build-ubuntu-docker {{ tag }} {{ version }}" >&2; \
+            echo "       or let the ubuntu-docker GitHub Actions workflow publish it." >&2; \
+            echo "       To override: just push-ubuntu-docker {{ tag }} {{ version }} true" >&2; \
+            exit 1; \
+          fi;; \
+     esac
     just ghcr-login
-    docker push {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}}
-    docker push {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:latest
+    @ref="{{DOCKER_NAMESPACE}}/ubuntu-{{ version }}"; \
+     for dest in "{{ tag }}" latest; do \
+       if docker manifest exists "$ref:{{ tag }}" 2>/dev/null; then \
+         docker manifest push --all "$ref:{{ tag }}" "docker://$ref:$dest"; \
+       else \
+         docker push "$ref:$dest"; \
+       fi; \
+     done
 
 # Release-named shortcuts
 build-jammy-docker tag="dev":
@@ -241,6 +313,15 @@ build-noble-docker-multi tag="dev":
 
 build-resolute-docker-multi tag="dev":
     just build-ubuntu-docker-multi {{ tag }} 26.04
+
+build-jammy-docker-native tag="dev":
+    just build-ubuntu-docker-native {{ tag }} 22.04
+
+build-noble-docker-native tag="dev":
+    just build-ubuntu-docker-native {{ tag }} 24.04
+
+build-resolute-docker-native tag="dev":
+    just build-ubuntu-docker-native {{ tag }} 26.04
 
 push-jammy-docker tag="dev":
     just push-ubuntu-docker {{ tag }} 22.04
@@ -300,24 +381,75 @@ link-ubuntu-docker-all tag="dev":
     just link-noble-docker {{ tag }}
     just link-resolute-docker {{ tag }}
 
-# Multi-arch build & push for Rocky
-build-rocky-docker-multi tag="dev":
-    docker buildx build \
-      --platform linux/amd64,linux/arm64/v8 \
-      -f docker/rocky/Dockerfile \
-      -t {{DOCKER_NAMESPACE}}/rocky-9:{{tag}} \
-      --push \
-      .
+# Multi-arch build for Rocky (default). Publishing is a separate step so a
+# failed build can never leave a half-published tag behind.
+build-rocky-docker tag="dev" platforms=DOCKER_PLATFORMS:
+    just check-emulation {{ platforms }}
+    just _free-image-name {{DOCKER_NAMESPACE}}/rocky-9:{{tag}}
+    @for platform in $(echo "{{ platforms }}" | tr ',' ' '); do \
+       echo "DOCKER: building Rocky 9 for $platform"; \
+       docker build \
+         --platform "$platform" \
+         -f docker/rocky/Dockerfile \
+         --manifest {{DOCKER_NAMESPACE}}/rocky-9:{{tag}} \
+         . || exit 1; \
+     done
 
-# Build Rocky 9 systemd-capable Ansible control image
-# Uses docker/rocky/Dockerfile
-build-rocky-docker tag="dev":
+# Build Rocky for the host architecture only (local iteration)
+build-rocky-docker-native tag="dev":
     docker build \
       -f docker/rocky/Dockerfile \
       -t {{DOCKER_NAMESPACE}}/rocky-9:{{tag}} \
       .
 
-# Push Rocky image to GHCR
-push-rocky-docker tag="dev":
+# Kept for discoverability; multi-arch is now the default
+build-rocky-docker-multi tag="dev":
+    just build-rocky-docker {{ tag }}
+
+# Alias a built Rocky image so the short local name, the fully qualified
+# GHCR name, and the GHCR :latest tag all point at it
+link-rocky-docker tag="dev":
+    @short="rocky-9:{{ tag }}"; \
+     full="{{DOCKER_NAMESPACE}}/rocky-9:{{ tag }}"; \
+     if ! docker image inspect "$full" >/dev/null 2>&1 \
+        && ! docker image inspect "$short" >/dev/null 2>&1; then \
+       echo "DOCKER: $full not found locally, building it first."; \
+       just build-rocky-docker {{ tag }}; \
+     fi; \
+     if docker image inspect "$full" >/dev/null 2>&1; then \
+       src="$full"; \
+     else \
+       src="$short"; \
+     fi; \
+     docker tag "$src" "$short"; \
+     docker tag "$src" "$full"; \
+     docker tag "$src" "{{DOCKER_NAMESPACE}}/rocky-9:latest"; \
+     echo "DOCKER: linked $src -> $short, $full, {{DOCKER_NAMESPACE}}/rocky-9:latest"
+
+# Push Rocky image to GHCR, including :latest so an untagged pull resolves
+push-rocky-docker tag="dev" force="false":
+    just link-rocky-docker {{ tag }}
+    @ref="{{DOCKER_NAMESPACE}}/rocky-9:{{ tag }}"; \
+     if docker manifest exists "$ref" 2>/dev/null; then \
+       archs=$(docker manifest inspect "$ref" | grep '"architecture"' | cut -d'"' -f4 | sort -u | tr '\n' ' '); \
+     else \
+       archs=$(docker image inspect "$ref" | grep -m1 '"Architecture"' | cut -d'"' -f4); \
+     fi; \
+     case " $archs " in \
+       *" {{ DOCKER_CI_ARCH }} "*) ;; \
+       *) if [ "{{ force }}" != "true" ]; then \
+            echo "ERROR: $ref covers [$archs] but downstream CI needs {{ DOCKER_CI_ARCH }}." >&2; \
+            echo "       Rebuild multi-arch: just build-rocky-docker {{ tag }}" >&2; \
+            echo "       To override: just push-rocky-docker {{ tag }} true" >&2; \
+            exit 1; \
+          fi;; \
+     esac
     just ghcr-login
-    docker push {{DOCKER_NAMESPACE}}/rocky-9:{{tag}}
+    @ref="{{DOCKER_NAMESPACE}}/rocky-9"; \
+     for dest in "{{ tag }}" latest; do \
+       if docker manifest exists "$ref:{{ tag }}" 2>/dev/null; then \
+         docker manifest push --all "$ref:{{ tag }}" "docker://$ref:$dest"; \
+       else \
+         docker push "$ref:$dest"; \
+       fi; \
+     done

--- a/justfile
+++ b/justfile
@@ -219,11 +219,17 @@ build-jammy-docker tag="dev":
 build-noble-docker tag="dev":
     just build-ubuntu-docker {{ tag }} 24.04
 
+build-resolute-docker tag="dev":
+    just build-ubuntu-docker {{ tag }} 26.04
+
 build-jammy-docker-multi tag="dev":
     just build-ubuntu-docker-multi {{ tag }} 22.04
 
 build-noble-docker-multi tag="dev":
     just build-ubuntu-docker-multi {{ tag }} 24.04
+
+build-resolute-docker-multi tag="dev":
+    just build-ubuntu-docker-multi {{ tag }} 26.04
 
 push-jammy-docker tag="dev":
     just push-ubuntu-docker {{ tag }} 22.04
@@ -231,11 +237,15 @@ push-jammy-docker tag="dev":
 push-noble-docker tag="dev":
     just push-ubuntu-docker {{ tag }} 24.04
 
-# Build both supported Ubuntu releases
+push-resolute-docker tag="dev":
+    just push-ubuntu-docker {{ tag }} 26.04
+
+# Build all supported Ubuntu releases
 build-ubuntu-docker-all tag="dev":
     just build-jammy-docker {{ tag }}
     just build-noble-docker {{ tag }}
-    @echo "DOCKER: Built Ubuntu 22.04 and 24.04 images tagged {{ tag }}."
+    just build-resolute-docker {{ tag }}
+    @echo "DOCKER: Built Ubuntu 22.04, 24.04 and 26.04 images tagged {{ tag }}."
 
 # Alias a built Ubuntu image so the short local name, the fully
 # qualified GHCR name, and the GHCR :latest tag all point at it
@@ -263,10 +273,14 @@ link-jammy-docker tag="dev":
 link-noble-docker tag="dev":
     just link-ubuntu-docker {{ tag }} 24.04
 
-# Link both supported Ubuntu releases
+link-resolute-docker tag="dev":
+    just link-ubuntu-docker {{ tag }} 26.04
+
+# Link all supported Ubuntu releases
 link-ubuntu-docker-all tag="dev":
     just link-jammy-docker {{ tag }}
     just link-noble-docker {{ tag }}
+    just link-resolute-docker {{ tag }}
 
 # Multi-arch build & push for Rocky
 build-rocky-docker-multi tag="dev":

--- a/justfile
+++ b/justfile
@@ -237,6 +237,37 @@ build-ubuntu-docker-all tag="dev":
     just build-noble-docker {{ tag }}
     @echo "DOCKER: Built Ubuntu 22.04 and 24.04 images tagged {{ tag }}."
 
+# Alias a built Ubuntu image so the short local name, the fully
+# qualified GHCR name, and the GHCR :latest tag all point at it
+link-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
+    @short="ubuntu-{{ version }}:{{ tag }}"; \
+     full="{{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{ tag }}"; \
+     if ! docker image inspect "$full" >/dev/null 2>&1 \
+        && ! docker image inspect "$short" >/dev/null 2>&1; then \
+       echo "DOCKER: $full not found locally, building it first."; \
+       just build-ubuntu-docker {{ tag }} {{ version }}; \
+     fi; \
+     if docker image inspect "$full" >/dev/null 2>&1; then \
+       src="$full"; \
+     else \
+       src="$short"; \
+     fi; \
+     docker tag "$src" "$short"; \
+     docker tag "$src" "$full"; \
+     docker tag "$src" "{{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:latest"; \
+     echo "DOCKER: linked $src -> $short, $full, {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:latest"
+
+link-jammy-docker tag="dev":
+    just link-ubuntu-docker {{ tag }} 22.04
+
+link-noble-docker tag="dev":
+    just link-ubuntu-docker {{ tag }} 24.04
+
+# Link both supported Ubuntu releases
+link-ubuntu-docker-all tag="dev":
+    just link-jammy-docker {{ tag }}
+    just link-noble-docker {{ tag }}
+
 # Multi-arch build & push for Rocky
 build-rocky-docker-multi tag="dev":
     docker buildx build \

--- a/justfile
+++ b/justfile
@@ -176,10 +176,15 @@ DOCKER_NAMESPACE := "ghcr.io/pulibrary/vm-builds"
 
 # Login helper.
 # Uses (in order): GHCR_PAT, GITHUB_TOKEN, GH_TOKEN
+# If no token is set but you are already logged in to ghcr.io, that is reused.
 ghcr-login:
     @user="${GITHUB_ACTOR:-pulibrary}"; \
      token="${GHCR_PAT:-${GITHUB_TOKEN:-$GH_TOKEN}}"; \
      if [ -z "$token" ]; then \
+       if docker login ghcr.io --get-login >/dev/null 2>&1; then \
+         echo "GHCR: reusing existing docker login for $(docker login ghcr.io --get-login)"; \
+         exit 0; \
+       fi; \
        echo "ERROR: Set GHCR_PAT (or GITHUB_TOKEN / GH_TOKEN) before running this." >&2; \
        exit 1; \
      fi; \
@@ -198,19 +203,25 @@ build-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
       .
 
 # Multi-arch build & push for Ubuntu
+# Publishes both the given tag and :latest so `docker pull` without a tag works
 build-ubuntu-docker-multi tag="dev" version=UBUNTU_DOCKER_VERSION:
+    just ghcr-login
     docker buildx build \
       --platform linux/amd64,linux/arm64/v8 \
       -f docker/ubuntu/Dockerfile \
       --build-arg UBUNTU_VERSION={{ version }} \
       -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}} \
+      -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:latest \
       --push \
       .
 
-# Push Ubuntu image to GHCR
+# Push Ubuntu image to GHCR, including the :latest tag so that
+# `docker pull ghcr.io/pulibrary/vm-builds/ubuntu-<version>` resolves
 push-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
+    just link-ubuntu-docker {{ tag }} {{ version }}
     just ghcr-login
     docker push {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}}
+    docker push {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:latest
 
 # Release-named shortcuts
 build-jammy-docker tag="dev":
@@ -246,6 +257,13 @@ build-ubuntu-docker-all tag="dev":
     just build-noble-docker {{ tag }}
     just build-resolute-docker {{ tag }}
     @echo "DOCKER: Built Ubuntu 22.04, 24.04 and 26.04 images tagged {{ tag }}."
+
+# Push all supported Ubuntu releases (builds and links whatever is missing)
+push-ubuntu-docker-all tag="dev":
+    just push-jammy-docker {{ tag }}
+    just push-noble-docker {{ tag }}
+    just push-resolute-docker {{ tag }}
+    @echo "DOCKER: Pushed Ubuntu 22.04, 24.04 and 26.04 images tagged {{ tag }} and latest."
 
 # Alias a built Ubuntu image so the short local name, the fully
 # qualified GHCR name, and the GHCR :latest tag all point at it

--- a/justfile
+++ b/justfile
@@ -185,27 +185,57 @@ ghcr-login:
      fi; \
      echo "$token" | docker login ghcr.io -u "$user" --password-stdin
 
-# Build Ubuntu 22.04 systemd-capable Ansible control image
-# Uses docker/ubuntu/Dockerfile
-build-ubuntu-docker tag="dev":
+# Default Ubuntu release used by the docker recipes
+UBUNTU_DOCKER_VERSION := "22.04"
+
+# Build an Ubuntu systemd-capable Ansible control image
+# Uses docker/ubuntu/Dockerfile; version selects the Ubuntu release (22.04, 24.04, ...)
+build-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
     docker build \
       -f docker/ubuntu/Dockerfile \
-      -t {{DOCKER_NAMESPACE}}/ubuntu-22.04:{{tag}} \
+      --build-arg UBUNTU_VERSION={{ version }} \
+      -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}} \
       .
 
 # Multi-arch build & push for Ubuntu
-build-ubuntu-docker-multi tag="dev":
+build-ubuntu-docker-multi tag="dev" version=UBUNTU_DOCKER_VERSION:
     docker buildx build \
       --platform linux/amd64,linux/arm64/v8 \
       -f docker/ubuntu/Dockerfile \
-      -t {{DOCKER_NAMESPACE}}/ubuntu-22.04:{{tag}} \
+      --build-arg UBUNTU_VERSION={{ version }} \
+      -t {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}} \
       --push \
       .
 
 # Push Ubuntu image to GHCR
-push-ubuntu-docker tag="dev":
+push-ubuntu-docker tag="dev" version=UBUNTU_DOCKER_VERSION:
     just ghcr-login
-    docker push {{DOCKER_NAMESPACE}}/ubuntu-22.04:{{tag}}
+    docker push {{DOCKER_NAMESPACE}}/ubuntu-{{ version }}:{{tag}}
+
+# Release-named shortcuts
+build-jammy-docker tag="dev":
+    just build-ubuntu-docker {{ tag }} 22.04
+
+build-noble-docker tag="dev":
+    just build-ubuntu-docker {{ tag }} 24.04
+
+build-jammy-docker-multi tag="dev":
+    just build-ubuntu-docker-multi {{ tag }} 22.04
+
+build-noble-docker-multi tag="dev":
+    just build-ubuntu-docker-multi {{ tag }} 24.04
+
+push-jammy-docker tag="dev":
+    just push-ubuntu-docker {{ tag }} 22.04
+
+push-noble-docker tag="dev":
+    just push-ubuntu-docker {{ tag }} 24.04
+
+# Build both supported Ubuntu releases
+build-ubuntu-docker-all tag="dev":
+    just build-jammy-docker {{ tag }}
+    just build-noble-docker {{ tag }}
+    @echo "DOCKER: Built Ubuntu 22.04 and 24.04 images tagged {{ tag }}."
 
 # Multi-arch build & push for Rocky
 build-rocky-docker-multi tag="dev":


### PR DESCRIPTION
The Ubuntu container image was pinned to a single release, so newer
  Ubuntu could not be tested without editing the image definition. The
  release is now selectable at build time, and both 22.04 and 24.04 build
  from the same definition.

  Ansible is installed into a dedicated virtual environment because newer
  Ubuntu releases block installing into the system Python, and container
  service tuning now tolerates units that only exist on some releases.